### PR TITLE
[NSA-7636] Get service roles endpoint fixes

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -7,5 +7,12 @@
     "strict": "off",
     "no-underscore-dangle": ["error", { "allowAfterThis": true }],
     "max-len": 0
+  },
+  "env": {
+    "node": true,
+    "jest": true
+  },
+  "parserOptions": {
+    "ecmaVersion": "latest"
   }
 }

--- a/Postman/Collections/Public API - Dev.postman_collection.json
+++ b/Postman/Collections/Public API - Dev.postman_collection.json
@@ -331,7 +331,7 @@
 						}
 					]
 				},
-				"description": "Gives all orgs associated with a user."
+				"description": "Returns all roles associated with a service."
 			},
 			"response": []
 		},

--- a/Postman/Collections/Public API - Pre-Prod.postman_collection.json
+++ b/Postman/Collections/Public API - Pre-Prod.postman_collection.json
@@ -777,7 +777,7 @@
 						}
 					]
 				},
-				"description": "Gives all orgs associated with a user."
+				"description": "Returns all roles associated with a service."
 			},
 			"response": []
 		}

--- a/Postman/Collections/Public API - Preprod.postman_collection.json
+++ b/Postman/Collections/Public API - Preprod.postman_collection.json
@@ -501,7 +501,7 @@
 						}
 					]
 				},
-				"description": "Gives all orgs associated with a user."
+				"description": "Returns all roles associated with a service."
 			},
 			"response": []
 		}

--- a/Postman/Collections/Public API - Production.postman_collection.json
+++ b/Postman/Collections/Public API - Production.postman_collection.json
@@ -777,7 +777,7 @@
 						}
 					]
 				},
-				"description": "Gives all orgs associated with a user."
+				"description": "Returns all roles associated with a service."
 			},
 			"response": []
 		}

--- a/Postman/Collections/Public API - Test.postman_collection.json
+++ b/Postman/Collections/Public API - Test.postman_collection.json
@@ -843,7 +843,7 @@
 						}
 					]
 				},
-				"description": "Gives all orgs associated with a user."
+				"description": "Returns all roles associated with a service."
 			},
 			"response": []
 		}

--- a/README.md
+++ b/README.md
@@ -385,22 +385,14 @@ This will return a response in the following format:
 ```
 [
     {
-        "id": "UUID-of-role",
         "name": "Role 1 Name",
         "code": "Role1Code",
-        "numericId": "123456",
-        "status": {
-            "id": 1
-        }
+        "status": "Active"
     },
     {
-        "id": "UUID-of-role2",
         "name": "Role 2 Name",
         "code": "Role2Code",
-        "numericId": "678910",
-        "status": {
-            "id": 1
-        }
+        "status": "Inactive"
     }
 ]
 ```

--- a/README.md
+++ b/README.md
@@ -358,8 +358,8 @@ This will return a response in the following format
 ```
 
 ## Get roles for service
-You can use this API to get the roles associated with a service
-The request looks like
+
+You can use this API endpoint to get the roles associated with your service, or one of your child services. The request looks like:
 ```
 GET https://environment-url/services/{client-id}/roles
 Authorization: bearer {jwt-token}
@@ -369,32 +369,46 @@ The variable data items are:
 
 | Name                  | Location | Required | Description |
 | --------------------- | -------- | -------- | ----------- |
-| client-id             | URL      | Y        | The DfE Sign-in client identifier for the service |
-| jwt-token             | Header   | Y        | The JWT token for authorization. You will be given a secret to use to sign the token |
+| client-id             | URL      | Y        | The DfE Sign-in client identifier for the service. |
+| jwt-token             | Header   | Y        | The JWT token for authorization. Signed with your API secret. |
 
-This will return a response in the following format
+ Possible response codes are:
+ 
+| HTTP Status Code | Reason |
+| ---------------- | ------ |
+| 200              | A (possibly empty) list of roles has been retrieved successfully for the requested client ID. |
+| 403              | The specified client ID is not your service, or a child of your service. |
+| 404              | No service can be found with the specified client ID. |
+
+This will return a response in the following format:
+
 ```
 [
     {
-        "clientId": "client-id",
-        "serviceName": "Service name",
+        "id": "UUID-of-role",
+        "name": "Role 1 Name",
+        "code": "Role1Code",
+        "numericId": "123456",
         "status": {
-            "id": 1,
-            "name": "Open"
-        },
-        "roles": [
-            {
-                "id": "role-id",
-                "name": "The name of the role",
-                "code": "The code of the role",
-                "numericId": "9999",
-                "status": {
-                    "id": 1
-                }
-            }
-        ]
+            "id": 1
+        }
     },
+    {
+        "id": "UUID-of-role2",
+        "name": "Role 2 Name",
+        "code": "Role2Code",
+        "numericId": "678910",
+        "status": {
+            "id": 1
+        }
+    }
 ]
+```
+
+or the following if no roles were found:
+
+```
+[]
 ```
 
 ## Get organisations for user including Provider Profile organisation attributes

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "login.dfe.healthcheck": "git+https://github.com/DFE-Digital/login.dfe.healthcheck.git#v3.0.0",
         "login.dfe.jwt-strategies": "git+https://github.com/DFE-Digital/login.dfe.jwt-strategies.git#v4.0.0",
         "login.dfe.public-api.jobs.client": "git+https://github.com/DFE-Digital/login.dfe.public-api.jobs.client.git#v3.0.0",
-        "login.dfe.request-promise-retry": "git+https://github.com/DFE-Digital/login.dfe.request-promise-retry.git#v3.0.0",
+        "login.dfe.request-promise-retry": "git+https://github.com/DFE-Digital/login.dfe.request-promise-retry.git#v3.1.0",
         "login.dfe.sanitization": "git+https://github.com/DFE-Digital/login.dfe.sanitization.git#v3.0.0",
         "login.dfe.winston-appinsights": "git+https://github.com/DFE-Digital/login.dfe.winston-appinsights.git#v5.0.0",
         "niceware": "^4.0.0",
@@ -61,29 +61,29 @@
       }
     },
     "node_modules/@ampproject/remapping": {
-      "version": "2.2.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@ampproject/remapping/-/remapping-2.2.1.tgz",
-      "integrity": "sha1-mejhGFESi4cCzVfDNoTx0PJgtjA=",
+      "version": "2.3.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha1-7UQbb6YAByUgzhi0PSyMyMrsx/Q=",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.0",
-        "@jridgewell/trace-mapping": "^0.3.9"
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
       },
       "engines": {
         "node": ">=6.0.0"
       }
     },
     "node_modules/@azure/abort-controller": {
-      "version": "1.1.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/abort-controller/-/abort-controller-1.1.0.tgz",
-      "integrity": "sha1-eI7nhFelWvihrTQqyxgjg9IRkkk=",
+      "version": "2.1.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/abort-controller/-/abort-controller-2.1.1.tgz",
+      "integrity": "sha1-rUqWTOUKHq7XDtLS73fI3lcI0Qs=",
       "license": "MIT",
       "dependencies": {
-        "tslib": "^2.2.0"
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@azure/amqp-common": {
@@ -140,35 +140,48 @@
       }
     },
     "node_modules/@azure/core-auth": {
-      "version": "1.5.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/core-auth/-/core-auth-1.5.0.tgz",
-      "integrity": "sha1-pBhIxcMcs7fITECYhSZ9VaLJLkQ=",
+      "version": "1.7.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/core-auth/-/core-auth-1.7.1.tgz",
+      "integrity": "sha1-ynW8ZjtkY2AvsQRx22Dwk2iho9I=",
       "license": "MIT",
       "dependencies": {
-        "@azure/abort-controller": "^1.0.0",
+        "@azure/abort-controller": "^2.0.0",
         "@azure/core-util": "^1.1.0",
-        "tslib": "^2.2.0"
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@azure/core-client": {
-      "version": "1.7.3",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/core-client/-/core-client-1.7.3.tgz",
-      "integrity": "sha1-+MsqH5HovEkh+i50XP39o+bkkaM=",
+      "version": "1.9.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/core-client/-/core-client-1.9.1.tgz",
+      "integrity": "sha1-t/w80ke6oeP+4fIVAkprborvWDo=",
       "license": "MIT",
       "dependencies": {
-        "@azure/abort-controller": "^1.0.0",
+        "@azure/abort-controller": "^2.0.0",
         "@azure/core-auth": "^1.4.0",
         "@azure/core-rest-pipeline": "^1.9.1",
         "@azure/core-tracing": "^1.0.0",
-        "@azure/core-util": "^1.0.0",
+        "@azure/core-util": "^1.6.1",
         "@azure/logger": "^1.0.0",
-        "tslib": "^2.2.0"
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/core-client/node_modules/@azure/core-util": {
+      "version": "1.8.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/core-util/-/core-util-1.8.1.tgz",
+      "integrity": "sha1-ShTdszjcGs8up2KLWxzM21tvv78=",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@azure/core-http": {
@@ -198,14 +211,26 @@
       }
     },
     "node_modules/@azure/core-http-compat": {
-      "version": "1.3.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/core-http-compat/-/core-http-compat-1.3.0.tgz",
-      "integrity": "sha1-vz2K4eMQED8rglUPNv0qmcm00/Q=",
+      "version": "2.1.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/core-http-compat/-/core-http-compat-2.1.1.tgz",
+      "integrity": "sha1-8c6vUljjEe8Ldft/KfpVGWZKHRg=",
       "license": "MIT",
       "dependencies": {
-        "@azure/abort-controller": "^1.0.4",
+        "@azure/abort-controller": "^2.0.0",
         "@azure/core-client": "^1.3.0",
         "@azure/core-rest-pipeline": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/core-http/node_modules/@azure/abort-controller": {
+      "version": "1.1.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/abort-controller/-/abort-controller-1.1.0.tgz",
+      "integrity": "sha1-eI7nhFelWvihrTQqyxgjg9IRkkk=",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.2.0"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -258,30 +283,30 @@
       }
     },
     "node_modules/@azure/core-lro": {
-      "version": "2.5.4",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/core-lro/-/core-lro-2.5.4.tgz",
-      "integrity": "sha1-sh4ry4vZqKZS/4W2Gt7qUagFX5A=",
+      "version": "2.7.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/core-lro/-/core-lro-2.7.1.tgz",
+      "integrity": "sha1-oRC6SlcJTeSy+jcoPeXyx/SH4fk=",
       "license": "MIT",
       "dependencies": {
-        "@azure/abort-controller": "^1.0.0",
+        "@azure/abort-controller": "^2.0.0",
         "@azure/core-util": "^1.2.0",
         "@azure/logger": "^1.0.0",
-        "tslib": "^2.2.0"
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@azure/core-paging": {
-      "version": "1.5.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/core-paging/-/core-paging-1.5.0.tgz",
-      "integrity": "sha1-WlsJNT5jYHLmp/w494eeEdCvsV8=",
+      "version": "1.6.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/core-paging/-/core-paging-1.6.1.tgz",
+      "integrity": "sha1-erpCk3Tv/JW4gB3j4O70pLoKJFc=",
       "license": "MIT",
       "dependencies": {
-        "tslib": "^2.2.0"
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@azure/core-rest-pipeline": {
@@ -305,6 +330,18 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@azure/core-rest-pipeline/node_modules/@azure/abort-controller": {
+      "version": "1.1.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/abort-controller/-/abort-controller-1.1.0.tgz",
+      "integrity": "sha1-eI7nhFelWvihrTQqyxgjg9IRkkk=",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/@azure/core-rest-pipeline/node_modules/uuid": {
       "version": "8.3.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/uuid/-/uuid-8.3.2.tgz",
@@ -315,15 +352,15 @@
       }
     },
     "node_modules/@azure/core-tracing": {
-      "version": "1.0.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/core-tracing/-/core-tracing-1.0.1.tgz",
-      "integrity": "sha1-NSo4y+pDjEqDyGsxT0gBfXC6lQM=",
+      "version": "1.1.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/core-tracing/-/core-tracing-1.1.1.tgz",
+      "integrity": "sha1-/ufQov8NOYitjXsFHU0WO3C7Ctk=",
       "license": "MIT",
       "dependencies": {
-        "tslib": "^2.2.0"
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@azure/core-util": {
@@ -339,6 +376,18 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@azure/core-util/node_modules/@azure/abort-controller": {
+      "version": "1.1.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/abort-controller/-/abort-controller-1.1.0.tgz",
+      "integrity": "sha1-eI7nhFelWvihrTQqyxgjg9IRkkk=",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/@azure/functions": {
       "version": "1.2.3",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/functions/-/functions-1.2.3.tgz",
@@ -346,30 +395,65 @@
       "license": "MIT"
     },
     "node_modules/@azure/identity": {
-      "version": "2.1.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/identity/-/identity-2.1.0.tgz",
-      "integrity": "sha1-ifC/wdEmTf09DLGYN8M6nGcG1Ug=",
+      "version": "3.4.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/identity/-/identity-3.4.2.tgz",
+      "integrity": "sha1-awFyTJyqx8ratrY8dlhDRb2o4t4=",
       "license": "MIT",
       "dependencies": {
         "@azure/abort-controller": "^1.0.0",
-        "@azure/core-auth": "^1.3.0",
+        "@azure/core-auth": "^1.5.0",
         "@azure/core-client": "^1.4.0",
         "@azure/core-rest-pipeline": "^1.1.0",
         "@azure/core-tracing": "^1.0.0",
-        "@azure/core-util": "^1.0.0",
+        "@azure/core-util": "^1.6.1",
         "@azure/logger": "^1.0.0",
-        "@azure/msal-browser": "^2.26.0",
-        "@azure/msal-common": "^7.0.0",
-        "@azure/msal-node": "^1.10.0",
+        "@azure/msal-browser": "^3.5.0",
+        "@azure/msal-node": "^2.5.1",
         "events": "^3.0.0",
         "jws": "^4.0.0",
         "open": "^8.0.0",
         "stoppable": "^1.1.0",
-        "tslib": "^2.2.0",
-        "uuid": "^8.3.0"
+        "tslib": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@azure/identity/node_modules/@azure/abort-controller": {
+      "version": "1.1.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/abort-controller/-/abort-controller-1.1.0.tgz",
+      "integrity": "sha1-eI7nhFelWvihrTQqyxgjg9IRkkk=",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.2.0"
       },
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@azure/identity/node_modules/@azure/core-util": {
+      "version": "1.8.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/core-util/-/core-util-1.8.1.tgz",
+      "integrity": "sha1-ShTdszjcGs8up2KLWxzM21tvv78=",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/identity/node_modules/@azure/core-util/node_modules/@azure/abort-controller": {
+      "version": "2.1.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/abort-controller/-/abort-controller-2.1.1.tgz",
+      "integrity": "sha1-rUqWTOUKHq7XDtLS73fI3lcI0Qs=",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@azure/identity/node_modules/jwa": {
@@ -393,25 +477,16 @@
         "safe-buffer": "^5.0.1"
       }
     },
-    "node_modules/@azure/identity/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha1-gNW1ztJxu5r2xEXyGhoExgbO++I=",
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/@azure/keyvault-keys": {
-      "version": "4.7.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/keyvault-keys/-/keyvault-keys-4.7.2.tgz",
-      "integrity": "sha1-UeuPaTq0pEgaFGHtK+WnKeZOpoQ=",
+      "version": "4.8.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/keyvault-keys/-/keyvault-keys-4.8.0.tgz",
+      "integrity": "sha1-FROzoYe7Opo3K1mAxZOWL7eTsq0=",
       "license": "MIT",
       "dependencies": {
         "@azure/abort-controller": "^1.0.0",
         "@azure/core-auth": "^1.3.0",
         "@azure/core-client": "^1.5.0",
-        "@azure/core-http-compat": "^1.3.0",
+        "@azure/core-http-compat": "^2.0.1",
         "@azure/core-lro": "^2.2.0",
         "@azure/core-paging": "^1.1.1",
         "@azure/core-rest-pipeline": "^1.8.1",
@@ -421,19 +496,31 @@
         "tslib": "^2.2.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=18.0.0"
       }
     },
-    "node_modules/@azure/logger": {
-      "version": "1.0.4",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/logger/-/logger-1.0.4.tgz",
-      "integrity": "sha1-KLxtDls8OO8pKWsy012k5INZP6E=",
+    "node_modules/@azure/keyvault-keys/node_modules/@azure/abort-controller": {
+      "version": "1.1.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/abort-controller/-/abort-controller-1.1.0.tgz",
+      "integrity": "sha1-eI7nhFelWvihrTQqyxgjg9IRkkk=",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.2.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@azure/logger": {
+      "version": "1.1.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/logger/-/logger-1.1.1.tgz",
+      "integrity": "sha1-XaoQ07as4RoSkdTt7A9w9snj3No=",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@azure/ms-rest-azure-env": {
@@ -556,56 +643,38 @@
       }
     },
     "node_modules/@azure/msal-browser": {
-      "version": "2.38.3",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/msal-browser/-/msal-browser-2.38.3.tgz",
-      "integrity": "sha1-LxMfqbeoqVRvyNNOXZnOTBiwQUc=",
+      "version": "3.11.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/msal-browser/-/msal-browser-3.11.1.tgz",
+      "integrity": "sha1-JRFccGhTTr6FzjZlP5dxtu9aLkY=",
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-common": "13.3.1"
+        "@azure/msal-common": "14.8.1"
       },
       "engines": {
         "node": ">=0.8.0"
       }
     },
-    "node_modules/@azure/msal-browser/node_modules/@azure/msal-common": {
-      "version": "13.3.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/msal-common/-/msal-common-13.3.1.tgz",
-      "integrity": "sha1-ASRlv5QNEjddxHOHt1TM+da5IYA=",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
     "node_modules/@azure/msal-common": {
-      "version": "7.6.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/msal-common/-/msal-common-7.6.0.tgz",
-      "integrity": "sha1-tS6X71QCdfcmEc/1eTffoLNM3Mo=",
+      "version": "14.8.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/msal-common/-/msal-common-14.8.1.tgz",
+      "integrity": "sha1-oOvhKiPxn29ITe04rNUlR08Fb/Y=",
       "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/@azure/msal-node": {
-      "version": "1.18.4",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/msal-node/-/msal-node-1.18.4.tgz",
-      "integrity": "sha1-ySGwRHyS+zsMsev1qadvytLsfCE=",
+      "version": "2.6.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/msal-node/-/msal-node-2.6.6.tgz",
+      "integrity": "sha1-ke6doYE32TR2+zoZaH8WGCFFJO8=",
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-common": "13.3.1",
+        "@azure/msal-common": "14.8.1",
         "jsonwebtoken": "^9.0.0",
         "uuid": "^8.3.0"
       },
       "engines": {
-        "node": "10 || 12 || 14 || 16 || 18"
-      }
-    },
-    "node_modules/@azure/msal-node/node_modules/@azure/msal-common": {
-      "version": "13.3.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/msal-common/-/msal-common-13.3.1.tgz",
-      "integrity": "sha1-ASRlv5QNEjddxHOHt1TM+da5IYA=",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
+        "node": ">=16"
       }
     },
     "node_modules/@azure/msal-node/node_modules/uuid": {
@@ -685,93 +754,22 @@
       "license": "0BSD"
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.22.13",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/code-frame/-/code-frame-7.22.13.tgz",
-      "integrity": "sha1-48HAmUAlmEg7eoxGpyHRA4gDdV4=",
+      "version": "7.24.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/code-frame/-/code-frame-7.24.2.tgz",
+      "integrity": "sha1-cYtLGYQYCaWLKbaM3oC8Xhqm2a4=",
       "license": "MIT",
       "dependencies": {
-        "@babel/highlight": "^7.22.13",
-        "chalk": "^2.4.2"
+        "@babel/highlight": "^7.24.2",
+        "picocolors": "^1.0.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/code-frame/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/code-frame/node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/code-frame/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha1-u3GFBpDh8TZWfeYp0tVHHe2kweg=",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/@babel/code-frame/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "license": "MIT"
-    },
-    "node_modules/@babel/code-frame/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/@babel/code-frame/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/code-frame/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/@babel/compat-data": {
-      "version": "7.23.3",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/compat-data/-/compat-data-7.23.3.tgz",
-      "integrity": "sha1-P+vVUlQeYrXog6Jes+/9fHN52xE=",
+      "version": "7.24.4",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/compat-data/-/compat-data-7.24.4.tgz",
+      "integrity": "sha1-bxAjcukJTyXZCMoNNPx0x0YGBZo=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -779,22 +777,22 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.23.3",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/core/-/core-7.23.3.tgz",
-      "integrity": "sha1-XsCciAO5H1HMiH3twmVKNYUoSck=",
+      "version": "7.24.4",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/core/-/core-7.24.4.tgz",
+      "integrity": "sha1-H3WEKOiODYxWOHR0G8T/xPcaRxc=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
-        "@babel/code-frame": "^7.22.13",
-        "@babel/generator": "^7.23.3",
-        "@babel/helper-compilation-targets": "^7.22.15",
+        "@babel/code-frame": "^7.24.2",
+        "@babel/generator": "^7.24.4",
+        "@babel/helper-compilation-targets": "^7.23.6",
         "@babel/helper-module-transforms": "^7.23.3",
-        "@babel/helpers": "^7.23.2",
-        "@babel/parser": "^7.23.3",
-        "@babel/template": "^7.22.15",
-        "@babel/traverse": "^7.23.3",
-        "@babel/types": "^7.23.3",
+        "@babel/helpers": "^7.24.4",
+        "@babel/parser": "^7.24.4",
+        "@babel/template": "^7.24.0",
+        "@babel/traverse": "^7.24.1",
+        "@babel/types": "^7.24.0",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -845,15 +843,15 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.23.3",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/generator/-/generator-7.23.3.tgz",
-      "integrity": "sha1-huboPZWQP752E/RIYTuLMZ8zCo4=",
+      "version": "7.24.4",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/generator/-/generator-7.24.4.tgz",
+      "integrity": "sha1-H8VVMriK35UgJdXS0ecflGyxxJg=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.23.3",
-        "@jridgewell/gen-mapping": "^0.3.2",
-        "@jridgewell/trace-mapping": "^0.3.17",
+        "@babel/types": "^7.24.0",
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25",
         "jsesc": "^2.5.1"
       },
       "engines": {
@@ -861,15 +859,15 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.22.15",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/helper-compilation-targets/-/helper-compilation-targets-7.22.15.tgz",
-      "integrity": "sha1-Bpj8RFUaJs8p8Y1GYtW/VFps/FI=",
+      "version": "7.23.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/helper-compilation-targets/-/helper-compilation-targets-7.23.6.tgz",
+      "integrity": "sha1-TXkGmxbLzxRhKJ7M+72BUBrjmZE=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.22.9",
-        "@babel/helper-validator-option": "^7.22.15",
-        "browserslist": "^4.21.9",
+        "@babel/compat-data": "^7.23.5",
+        "@babel/helper-validator-option": "^7.23.5",
+        "browserslist": "^4.22.2",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
       },
@@ -925,13 +923,13 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.22.15",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/helper-module-imports/-/helper-module-imports-7.22.15.tgz",
-      "integrity": "sha1-FhRjB6zcQMwAw7LGR3EwdkZL2/A=",
+      "version": "7.24.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/helper-module-imports/-/helper-module-imports-7.24.3.tgz",
+      "integrity": "sha1-asR25tFox8I/87o89PeEHUasgSg=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.22.15"
+        "@babel/types": "^7.24.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -958,9 +956,9 @@
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.22.5",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/helper-plugin-utils/-/helper-plugin-utils-7.22.5.tgz",
-      "integrity": "sha1-3X7jc16KMTufewWnc9iS6I5tcpU=",
+      "version": "7.24.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.0.tgz",
+      "integrity": "sha1-lFaBkxpS8Vzoef1bhs4trm09fyo=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -994,9 +992,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.22.5",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz",
-      "integrity": "sha1-Uz82RXolgUzx32SIUjrVR9eEqZ8=",
+      "version": "7.24.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/helper-string-parser/-/helper-string-parser-7.24.1.tgz",
+      "integrity": "sha1-+Zw201k9uVQHBdBzmh8QteIMaW4=",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -1012,9 +1010,9 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.22.15",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/helper-validator-option/-/helper-validator-option-7.22.15.tgz",
-      "integrity": "sha1-aUww36HQmmU0zfyvvlZ4nTaroEA=",
+      "version": "7.23.5",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/helper-validator-option/-/helper-validator-option-7.23.5.tgz",
+      "integrity": "sha1-kHo/vUUjQmKFNl0SBsQjxMVSAwc=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1022,29 +1020,30 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.23.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/helpers/-/helpers-7.23.2.tgz",
-      "integrity": "sha1-KDJUmm431IQobhW6NqUzBIPKx2c=",
+      "version": "7.24.4",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/helpers/-/helpers-7.24.4.tgz",
+      "integrity": "sha1-3ACQf9DZXadFY8FC70zSHyy4VrY=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.22.15",
-        "@babel/traverse": "^7.23.2",
-        "@babel/types": "^7.23.0"
+        "@babel/template": "^7.24.0",
+        "@babel/traverse": "^7.24.1",
+        "@babel/types": "^7.24.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.22.20",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/highlight/-/highlight-7.22.20.tgz",
-      "integrity": "sha1-TKkrcdgFVLAUJ4FeBvLfllucH1Q=",
+      "version": "7.24.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/highlight/-/highlight-7.24.2.tgz",
+      "integrity": "sha1-P1OVA+/IPTxZCAoQ5mNDBuA3DSY=",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.22.20",
         "chalk": "^2.4.2",
-        "js-tokens": "^4.0.0"
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.0.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1122,9 +1121,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.23.3",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/parser/-/parser-7.23.3.tgz",
-      "integrity": "sha1-DOC+MaTKTxiEtXhgV8rctsO+WPk=",
+      "version": "7.24.4",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/parser/-/parser-7.24.4.tgz",
+      "integrity": "sha1-I0SHoRDYmtWj7UqKVmw2uUU+jIg=",
       "license": "MIT",
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -1199,13 +1198,13 @@
       }
     },
     "node_modules/@babel/plugin-syntax-jsx": {
-      "version": "7.23.3",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.23.3.tgz",
-      "integrity": "sha1-jy5PiptfmqFgZ+FCwayc2fgQ9HM=",
+      "version": "7.24.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.24.1.tgz",
+      "integrity": "sha1-P2ygS4yEGBHbw8XF+DeTTg1ibBA=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.22.5"
+        "@babel/helper-plugin-utils": "^7.24.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1309,13 +1308,13 @@
       }
     },
     "node_modules/@babel/plugin-syntax-typescript": {
-      "version": "7.23.3",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.23.3.tgz",
-      "integrity": "sha1-JPRgyF27yYPNK5xJlBeLzAHflY8=",
+      "version": "7.24.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.24.1.tgz",
+      "integrity": "sha1-s7zFHzltFfNZFoP5AjneFDwHaEQ=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.22.5"
+        "@babel/helper-plugin-utils": "^7.24.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1325,36 +1324,36 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.22.15",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/template/-/template-7.22.15.tgz",
-      "integrity": "sha1-CVdu/Dgw8EMPRUjvlx3eE1DvLzg=",
+      "version": "7.24.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/template/-/template-7.24.0.tgz",
+      "integrity": "sha1-xqUkqpOkoF1mqvMWVCWPrmnYfVA=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.22.13",
-        "@babel/parser": "^7.22.15",
-        "@babel/types": "^7.22.15"
+        "@babel/code-frame": "^7.23.5",
+        "@babel/parser": "^7.24.0",
+        "@babel/types": "^7.24.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.23.3",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/traverse/-/traverse-7.23.3.tgz",
-      "integrity": "sha1-Ju5fJS5yWqeso0dKpbMk6veQi1s=",
+      "version": "7.24.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/traverse/-/traverse-7.24.1.tgz",
+      "integrity": "sha1-1lw2rJ3RcoIXXR5KPEnVt5iPUww=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.22.13",
-        "@babel/generator": "^7.23.3",
+        "@babel/code-frame": "^7.24.1",
+        "@babel/generator": "^7.24.1",
         "@babel/helper-environment-visitor": "^7.22.20",
         "@babel/helper-function-name": "^7.23.0",
         "@babel/helper-hoist-variables": "^7.22.5",
         "@babel/helper-split-export-declaration": "^7.22.6",
-        "@babel/parser": "^7.23.3",
-        "@babel/types": "^7.23.3",
-        "debug": "^4.1.0",
+        "@babel/parser": "^7.24.1",
+        "@babel/types": "^7.24.0",
+        "debug": "^4.3.1",
         "globals": "^11.1.0"
       },
       "engines": {
@@ -1397,12 +1396,12 @@
       "license": "MIT"
     },
     "node_modules/@babel/types": {
-      "version": "7.23.3",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/types/-/types-7.23.3.tgz",
-      "integrity": "sha1-1eqJLAfy7DcaxwRCD03NsHtflZg=",
+      "version": "7.24.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/types/-/types-7.24.0.tgz",
+      "integrity": "sha1-O5UfQ1qS5zM+ugW3Vm/Sl5YOob8=",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.22.5",
+        "@babel/helper-string-parser": "^7.23.4",
         "@babel/helper-validator-identifier": "^7.22.20",
         "to-fast-properties": "^2.0.0"
       },
@@ -1462,9 +1461,9 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "2.1.3",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@eslint/eslintrc/-/eslintrc-2.1.3.tgz",
-      "integrity": "sha1-eXRwp1/g+9WlM1DucV6F6Huv8i0=",
+      "version": "2.1.4",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
+      "integrity": "sha1-OIomnw8lwbatwxe1osVXFIlMcK0=",
       "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.4",
@@ -1508,22 +1507,22 @@
       "license": "MIT"
     },
     "node_modules/@eslint/js": {
-      "version": "8.53.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@eslint/js/-/js-8.53.0.tgz",
-      "integrity": "sha1-vqVvLtK1uuoWQ0j/TVqHn2+B8g0=",
+      "version": "8.57.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@eslint/js/-/js-8.57.0.tgz",
+      "integrity": "sha1-pUF66EJ4c/HdCLcLNXS0U+Z7X38=",
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
-      "version": "0.11.13",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@humanwhocodes/config-array/-/config-array-0.11.13.tgz",
-      "integrity": "sha1-B13JaE9ApTHZsmsIIhU8HoMu4pc=",
+      "version": "0.11.14",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
+      "integrity": "sha1-145IGgOfdWbsyWYLTqf+ax/sRCs=",
       "license": "Apache-2.0",
       "dependencies": {
-        "@humanwhocodes/object-schema": "^2.0.1",
-        "debug": "^4.1.1",
+        "@humanwhocodes/object-schema": "^2.0.2",
+        "debug": "^4.3.1",
         "minimatch": "^3.0.5"
       },
       "engines": {
@@ -1567,9 +1566,9 @@
       }
     },
     "node_modules/@humanwhocodes/object-schema": {
-      "version": "2.0.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@humanwhocodes/object-schema/-/object-schema-2.0.1.tgz",
-      "integrity": "sha1-5SEUUt8GD6hSK1XHs8DE0ZgcsEQ=",
+      "version": "2.0.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
+      "integrity": "sha1-Siho111taWPkI7z5C3/RvjQ0CdM=",
       "license": "BSD-3-Clause"
     },
     "node_modules/@ioredis/commands": {
@@ -1995,24 +1994,24 @@
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.3",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
-      "integrity": "sha1-fgLm6135AartsIUUIDsJZhQCQJg=",
+      "version": "0.3.5",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
+      "integrity": "sha1-3M5q/3S99trRqVgCtpsEovyx+zY=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jridgewell/set-array": "^1.0.1",
+        "@jridgewell/set-array": "^1.2.1",
         "@jridgewell/sourcemap-codec": "^1.4.10",
-        "@jridgewell/trace-mapping": "^0.3.9"
+        "@jridgewell/trace-mapping": "^0.3.24"
       },
       "engines": {
         "node": ">=6.0.0"
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
-      "version": "3.1.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
-      "integrity": "sha1-wIZ5Bj8nlhWjMmWDujqQ0dgsxyE=",
+      "version": "3.1.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha1-eg7mAfYPmaIMfHxf8MgDiMEYm9Y=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2020,9 +2019,9 @@
       }
     },
     "node_modules/@jridgewell/set-array": {
-      "version": "1.1.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@jridgewell/set-array/-/set-array-1.1.2.tgz",
-      "integrity": "sha1-fGz5mNbSC5FMClWpGuko/yWWXnI=",
+      "version": "1.2.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@jridgewell/set-array/-/set-array-1.2.1.tgz",
+      "integrity": "sha1-VY+2Ry7RakyFC4iVMOazZDjEkoA=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2037,9 +2036,9 @@
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.20",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@jridgewell/trace-mapping/-/trace-mapping-0.3.20.tgz",
-      "integrity": "sha1-cuRXB88kD6awgdA2b4JlsM0QGX8=",
+      "version": "0.3.25",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+      "integrity": "sha1-FfGQ6YiV8/wjJ27hS8drZ1wuUPA=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2104,27 +2103,27 @@
       }
     },
     "node_modules/@opentelemetry/api": {
-      "version": "1.7.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@opentelemetry/api/-/api-1.7.0.tgz",
-      "integrity": "sha1-sTnIGZnCPjyNPApyNEgOlFkg/EA=",
+      "version": "1.8.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@opentelemetry/api/-/api-1.8.0.tgz",
+      "integrity": "sha1-WqertI8j9pMGjtKZmuYn0vfZAuw=",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8.0.0"
       }
     },
     "node_modules/@opentelemetry/core": {
-      "version": "1.18.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@opentelemetry/core/-/core-1.18.1.tgz",
-      "integrity": "sha1-0uRfa9a+TwDSDRjU8bIw7DOAWuk=",
+      "version": "1.23.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@opentelemetry/core/-/core-1.23.0.tgz",
+      "integrity": "sha1-8uetp/NXUPPBZ0rvHlLIeQBcBzE=",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.18.1"
+        "@opentelemetry/semantic-conventions": "1.23.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.8.0"
+        "@opentelemetry/api": ">=1.0.0 <1.9.0"
       }
     },
     "node_modules/@opentelemetry/instrumentation": {
@@ -2147,42 +2146,42 @@
       }
     },
     "node_modules/@opentelemetry/resources": {
-      "version": "1.18.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@opentelemetry/resources/-/resources-1.18.1.tgz",
-      "integrity": "sha1-4nvcRxW8zIzUpy1KyjmVrQpJb+c=",
+      "version": "1.23.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@opentelemetry/resources/-/resources-1.23.0.tgz",
+      "integrity": "sha1-THFDDz4gxNiLZ+9WKXWfrhCEheU=",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.18.1",
-        "@opentelemetry/semantic-conventions": "1.18.1"
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/semantic-conventions": "1.23.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.8.0"
+        "@opentelemetry/api": ">=1.0.0 <1.9.0"
       }
     },
     "node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "1.18.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.18.1.tgz",
-      "integrity": "sha1-JWYF2QsgIALVZyMFxm2883cTI3k=",
+      "version": "1.23.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.23.0.tgz",
+      "integrity": "sha1-/woPjsRyBeCxSzt2XqKjTeGtAd0=",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.18.1",
-        "@opentelemetry/resources": "1.18.1",
-        "@opentelemetry/semantic-conventions": "1.18.1"
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/resources": "1.23.0",
+        "@opentelemetry/semantic-conventions": "1.23.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.8.0"
+        "@opentelemetry/api": ">=1.0.0 <1.9.0"
       }
     },
     "node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.18.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@opentelemetry/semantic-conventions/-/semantic-conventions-1.18.1.tgz",
-      "integrity": "sha1-jkfK9XqEsdzBcisgJWkzSM30Q7Q=",
+      "version": "1.23.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@opentelemetry/semantic-conventions/-/semantic-conventions-1.23.0.tgz",
+      "integrity": "sha1-Yn8nIblg/lhrf3KgeRLLdpnwbu8=",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
@@ -2205,9 +2204,9 @@
       "license": "MIT"
     },
     "node_modules/@sinonjs/commons": {
-      "version": "3.0.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@sinonjs/commons/-/commons-3.0.0.tgz",
-      "integrity": "sha1-vrQ0/oddllJl4EcizPwh3391XXI=",
+      "version": "3.0.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@sinonjs/commons/-/commons-3.0.1.tgz",
+      "integrity": "sha1-ECk1fkTKkBphVYX20nc428iQhM0=",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -2240,9 +2239,9 @@
       "license": "MIT"
     },
     "node_modules/@types/babel__core": {
-      "version": "7.20.4",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/babel__core/-/babel__core-7.20.4.tgz",
-      "integrity": "sha1-JqhzR+bG91OzZoOY40SW1tmsasA=",
+      "version": "7.20.5",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha1-PfFfJ7qFMZyqB7oI0HIYibs5wBc=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2254,9 +2253,9 @@
       }
     },
     "node_modules/@types/babel__generator": {
-      "version": "7.6.7",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/babel__generator/-/babel__generator-7.6.7.tgz",
-      "integrity": "sha1-p66/Fce8Drmr1ji9tcC4cAOZydA=",
+      "version": "7.6.8",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/babel__generator/-/babel__generator-7.6.8.tgz",
+      "integrity": "sha1-+DbGH0ixNG59Kw2TxtrMW5U106s=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2275,9 +2274,9 @@
       }
     },
     "node_modules/@types/babel__traverse": {
-      "version": "7.20.4",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/babel__traverse/-/babel__traverse-7.20.4.tgz",
-      "integrity": "sha1-7CwG/tZUnfi8DrRhW2g3SaSpLhs=",
+      "version": "7.20.5",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/babel__traverse/-/babel__traverse-7.20.5.tgz",
+      "integrity": "sha1-e3UCvgqoDMTvIpeIRrmD7ar81N0=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2285,9 +2284,9 @@
       }
     },
     "node_modules/@types/babel-types": {
-      "version": "7.0.14",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/babel-types/-/babel-types-7.0.14.tgz",
-      "integrity": "sha1-E+kyMWLCaE6F1W52/5bCLP7v9X8=",
+      "version": "7.0.15",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/babel-types/-/babel-types-7.0.15.tgz",
+      "integrity": "sha1-EfsataT5hNANHICnaPb7jVn5aWY=",
       "license": "MIT"
     },
     "node_modules/@types/babylon": {
@@ -2299,6 +2298,27 @@
         "@types/babel-types": "*"
       }
     },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.5",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/body-parser/-/body-parser-1.19.5.tgz",
+      "integrity": "sha1-BM6aO2d9yL1oGhfaGrmDXcnT7eQ=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha1-W6fzvE+73q/43e2VLl/yzFP42Fg=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.12",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/debug/-/debug-4.1.12.tgz",
@@ -2306,6 +2326,32 @@
       "license": "MIT",
       "dependencies": {
         "@types/ms": "*"
+      }
+    },
+    "node_modules/@types/express": {
+      "version": "4.17.21",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/express/-/express-4.17.21.tgz",
+      "integrity": "sha1-wm1KFR5g7+AISyPcM2nrxjHtGS0=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.33",
+        "@types/qs": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "4.19.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/express-serve-static-core/-/express-serve-static-core-4.19.0.tgz",
+      "integrity": "sha1-OuirN2fZjQtoLNoGPDM54ehsz6o=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
       }
     },
     "node_modules/@types/graceful-fs": {
@@ -2317,6 +2363,13 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.4",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/http-errors/-/http-errors-2.0.4.tgz",
+      "integrity": "sha1-frR3JsORtzRabsNa1/TeRpz1uk8=",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/is-buffer": {
       "version": "2.0.2",
@@ -2367,6 +2420,13 @@
       "integrity": "sha1-t0EpcZ/I0RwBhoAQCC1IO3VFWRo=",
       "license": "MIT"
     },
+    "node_modules/@types/mime": {
+      "version": "1.3.5",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/mime/-/mime-1.3.5.tgz",
+      "integrity": "sha1-HvMC4Bz30rWg+lJnkMkSO/HQZpA=",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/ms": {
       "version": "0.7.34",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/ms/-/ms-0.7.34.tgz",
@@ -2374,23 +2434,53 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.9.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/node/-/node-20.9.1.tgz",
-      "integrity": "sha1-nVeMYQzh6YSt2gh/aFrOlAlU/hk=",
+      "version": "20.12.4",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/node/-/node-20.12.4.tgz",
+      "integrity": "sha1-r1khvXXM3zo9iz+nW/PTNZJozRE=",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~5.26.4"
       }
     },
     "node_modules/@types/node-fetch": {
-      "version": "2.6.9",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/node-fetch/-/node-fetch-2.6.9.tgz",
-      "integrity": "sha1-FfUp0kfx7eGCT356zaoZLV8oBx4=",
+      "version": "2.6.11",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/node-fetch/-/node-fetch-2.6.11.tgz",
+      "integrity": "sha1-mzm3hmXa4OgqCPAvSWfWLGb5XSQ=",
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
         "form-data": "^4.0.0"
       }
+    },
+    "node_modules/@types/qs": {
+      "version": "6.9.14",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/qs/-/qs-6.9.14.tgz",
+      "integrity": "sha1-Fp4UK/5JOJUoe+44KvYDl5Xpt1s=",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha1-UK5DU+qt3AQEQnmBL1LIxlhX28s=",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/readable-stream": {
+      "version": "4.0.11",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/readable-stream/-/readable-stream-4.0.11.tgz",
+      "integrity": "sha1-aE8elHyQy2qK05BFI9ZQu2bNu4Q=",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "safe-buffer": "~5.1.1"
+      }
+    },
+    "node_modules/@types/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
+      "license": "MIT"
     },
     "node_modules/@types/redis": {
       "version": "2.8.32",
@@ -2399,6 +2489,29 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/send": {
+      "version": "0.17.4",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/send/-/send-0.17.4.tgz",
+      "integrity": "sha1-ZhnNJOcnB5NwLk5qS5WKkBDPxXo=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "1.15.7",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/serve-static/-/serve-static-1.15.7.tgz",
+      "integrity": "sha1-IhdLvXT7l/4wMQlzjptcLzBk9xQ=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*",
+        "@types/send": "*"
       }
     },
     "node_modules/@types/shimmer": {
@@ -2430,15 +2543,15 @@
       }
     },
     "node_modules/@types/validator": {
-      "version": "13.11.6",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/validator/-/validator-13.11.6.tgz",
-      "integrity": "sha1-hkXv7f2JG8HXrYJTkAXX/3hf4pQ=",
+      "version": "13.11.9",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/validator/-/validator-13.11.9.tgz",
+      "integrity": "sha1-rf6WUgtDeg6qeYpHWHe/L3XuQC0=",
       "license": "MIT"
     },
     "node_modules/@types/yargs": {
-      "version": "17.0.31",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/yargs/-/yargs-17.0.31.tgz",
-      "integrity": "sha1-j9AImAP9VdiihYlaGLiMtxqZaDw=",
+      "version": "17.0.32",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/yargs/-/yargs-17.0.32.tgz",
+      "integrity": "sha1-Awd0cjovf6r+v2RfTlpINx3KYik=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2500,9 +2613,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.11.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/acorn/-/acorn-8.11.2.tgz",
-      "integrity": "sha1-yg14tRiVvlOQpZA8Wzvc2veK5As=",
+      "version": "8.11.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/acorn/-/acorn-8.11.3.tgz",
+      "integrity": "sha1-ceCxThOk7BYHJLOPt7DyM7G4HXo=",
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -2767,24 +2880,24 @@
       }
     },
     "node_modules/applicationinsights": {
-      "version": "2.9.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/applicationinsights/-/applicationinsights-2.9.1.tgz",
-      "integrity": "sha1-dpQS+AnWoHJIfktBxMOilng0TYI=",
+      "version": "2.9.5",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/applicationinsights/-/applicationinsights-2.9.5.tgz",
+      "integrity": "sha1-NLz3GtWWchxSCYeiUuQNdJWqNQM=",
       "license": "MIT",
       "dependencies": {
         "@azure/core-auth": "^1.5.0",
         "@azure/core-rest-pipeline": "1.10.1",
         "@azure/core-util": "1.2.0",
         "@azure/opentelemetry-instrumentation-azure-sdk": "^1.0.0-beta.5",
-        "@microsoft/applicationinsights-web-snippet": "^1.0.1",
-        "@opentelemetry/api": "^1.4.1",
-        "@opentelemetry/core": "^1.15.2",
-        "@opentelemetry/sdk-trace-base": "^1.15.2",
-        "@opentelemetry/semantic-conventions": "^1.15.2",
+        "@microsoft/applicationinsights-web-snippet": "1.0.1",
+        "@opentelemetry/api": "^1.7.0",
+        "@opentelemetry/core": "^1.19.0",
+        "@opentelemetry/sdk-trace-base": "^1.19.0",
+        "@opentelemetry/semantic-conventions": "^1.19.0",
         "cls-hooked": "^4.2.2",
         "continuation-local-storage": "^3.2.1",
         "diagnostic-channel": "1.1.1",
-        "diagnostic-channel-publishers": "1.0.7"
+        "diagnostic-channel-publishers": "1.0.8"
       },
       "engines": {
         "node": ">=8.0.0"
@@ -2805,13 +2918,16 @@
       "license": "Python-2.0"
     },
     "node_modules/array-buffer-byte-length": {
-      "version": "1.0.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/array-buffer-byte-length/-/array-buffer-byte-length-1.0.0.tgz",
-      "integrity": "sha1-+r6LwZP+qGXzF/54Bwhe4N7lrq0=",
+      "version": "1.0.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/array-buffer-byte-length/-/array-buffer-byte-length-1.0.1.tgz",
+      "integrity": "sha1-HlWD7BZ2NUCieuUu7Zn/iZIjVo8=",
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "is-array-buffer": "^3.0.1"
+        "call-bind": "^1.0.5",
+        "is-array-buffer": "^3.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -2824,16 +2940,17 @@
       "license": "MIT"
     },
     "node_modules/array-includes": {
-      "version": "3.1.7",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/array-includes/-/array-includes-3.1.7.tgz",
-      "integrity": "sha1-jNLgGyb3owhsvIcnFZP+khxiq9o=",
+      "version": "3.1.8",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/array-includes/-/array-includes-3.1.8.tgz",
+      "integrity": "sha1-XjcMvhcv3V3WUwwdSq3aJSgbqX0=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "es-abstract": "^1.22.1",
-        "get-intrinsic": "^1.2.1",
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.4",
         "is-string": "^1.0.7"
       },
       "engines": {
@@ -2844,17 +2961,18 @@
       }
     },
     "node_modules/array.prototype.findlastindex": {
-      "version": "1.2.3",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.3.tgz",
-      "integrity": "sha1-s3WYQ4+XtXkWaUCBTiwEk6T1Agc=",
+      "version": "1.2.5",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.5.tgz",
+      "integrity": "sha1-jDWnVccpCHGUU/hxRcoBHjkzTQ0=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "es-abstract": "^1.22.1",
-        "es-shim-unscopables": "^1.0.0",
-        "get-intrinsic": "^1.2.1"
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "es-shim-unscopables": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -2902,17 +3020,18 @@
       }
     },
     "node_modules/arraybuffer.prototype.slice": {
-      "version": "1.0.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.2.tgz",
-      "integrity": "sha1-mL1WGVPj50uzSTjndkcXnf5unxI=",
+      "version": "1.0.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.3.tgz",
+      "integrity": "sha1-CXly9CVeQbw0JeN9w/ZCHPmu/eY=",
       "license": "MIT",
       "dependencies": {
-        "array-buffer-byte-length": "^1.0.0",
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "es-abstract": "^1.22.1",
-        "get-intrinsic": "^1.2.1",
-        "is-array-buffer": "^3.0.2",
+        "array-buffer-byte-length": "^1.0.1",
+        "call-bind": "^1.0.5",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.22.3",
+        "es-errors": "^1.2.1",
+        "get-intrinsic": "^1.2.3",
+        "is-array-buffer": "^3.0.4",
         "is-shared-array-buffer": "^1.0.2"
       },
       "engines": {
@@ -3002,9 +3121,9 @@
       }
     },
     "node_modules/async-lock": {
-      "version": "1.4.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/async-lock/-/async-lock-1.4.0.tgz",
-      "integrity": "sha1-yLZjDv9o+73Ypbbrdj2sO/u4vwI=",
+      "version": "1.4.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/async-lock/-/async-lock-1.4.1.tgz",
+      "integrity": "sha1-VrhxiRWptosQ/OLyqaPd33Ze9T8=",
       "license": "MIT"
     },
     "node_modules/asynckit": {
@@ -3026,10 +3145,13 @@
       }
     },
     "node_modules/available-typed-arrays": {
-      "version": "1.0.5",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
-      "integrity": "sha1-kvlWFlAQadB9EO2y/DfT4cZRI7c=",
+      "version": "1.0.7",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha1-pcw3XWoDwu/IelU/PgsVIt7xSEY=",
       "license": "MIT",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -3319,13 +3441,16 @@
       }
     },
     "node_modules/binary-extensions": {
-      "version": "2.2.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/binary-extensions/-/binary-extensions-2.2.0.tgz",
-      "integrity": "sha1-dfUC7q+f/eQvyYgpZFvk6na9ni0=",
+      "version": "2.3.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha1-9uFKl4WNMnJSIAJC1Mz+UixEVSI=",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/binary-search": {
@@ -3411,9 +3536,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.22.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/browserslist/-/browserslist-4.22.1.tgz",
-      "integrity": "sha1-upGVjRpZuH2rb+2N+8s9peLpxhk=",
+      "version": "4.23.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/browserslist/-/browserslist-4.23.0.tgz",
+      "integrity": "sha1-jzrMK75zr3ITOZQwiQ+GxjpWdKs=",
       "dev": true,
       "funding": [
         {
@@ -3431,9 +3556,9 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "caniuse-lite": "^1.0.30001541",
-        "electron-to-chromium": "^1.4.535",
-        "node-releases": "^2.0.13",
+        "caniuse-lite": "^1.0.30001587",
+        "electron-to-chromium": "^1.4.668",
+        "node-releases": "^2.0.14",
         "update-browserslist-db": "^1.0.13"
       },
       "bin": {
@@ -3489,15 +3614,6 @@
       "integrity": "sha1-KxRqb9cugLT1XSVfNe1Zo6mkG9U=",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/buffer-writer": {
-      "version": "2.0.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/buffer-writer/-/buffer-writer-2.0.0.tgz",
-      "integrity": "sha1-zn64Gjj3gp2wnIc/L7t5LAyY7AQ=",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
     },
     "node_modules/bunyan": {
       "version": "1.8.15",
@@ -3562,14 +3678,19 @@
       "license": "ISC"
     },
     "node_modules/call-bind": {
-      "version": "1.0.5",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/call-bind/-/call-bind-1.0.5.tgz",
-      "integrity": "sha1-b6K3hFzg6km/TYue9kcnosLi5RM=",
+      "version": "1.0.7",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/call-bind/-/call-bind-1.0.7.tgz",
+      "integrity": "sha1-BgFlmcQMVkmMGHadJzC+JCtvo7k=",
       "license": "MIT",
       "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
         "function-bind": "^1.1.2",
-        "get-intrinsic": "^1.2.1",
-        "set-function-length": "^1.1.1"
+        "get-intrinsic": "^1.2.4",
+        "set-function-length": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3595,9 +3716,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001563",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/caniuse-lite/-/caniuse-lite-1.0.30001563.tgz",
-      "integrity": "sha1-qmimQYiQPpjzbrnFbkj7oMH+KjI=",
+      "version": "1.0.30001606",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/caniuse-lite/-/caniuse-lite-1.0.30001606.tgz",
+      "integrity": "sha1-tNX2erB0ajuLW20fBuOcUb6zmp4=",
       "dev": true,
       "funding": [
         {
@@ -3676,16 +3797,10 @@
       "license": "MIT"
     },
     "node_modules/chokidar": {
-      "version": "3.5.3",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/chokidar/-/chokidar-3.5.3.tgz",
-      "integrity": "sha1-HPN8hwe5Mr0a8a4iwEMuKs0ZA70=",
+      "version": "3.6.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha1-GXxsxmnvKo3F57TZfuTgksPrDVs=",
       "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://paulmillr.com/funding/"
-        }
-      ],
       "license": "MIT",
       "dependencies": {
         "anymatch": "~3.1.2",
@@ -3698,6 +3813,9 @@
       },
       "engines": {
         "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       },
       "optionalDependencies": {
         "fsevents": "~2.3.2"
@@ -4010,9 +4128,9 @@
       "license": "MIT"
     },
     "node_modules/cookie": {
-      "version": "0.5.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/cookie/-/cookie-0.5.0.tgz",
-      "integrity": "sha1-0fXXGt7GVYxY84mYfDZqpH6ZT4s=",
+      "version": "0.6.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha1-J5iwSwcbDsv/DbtipQWo76ThkFE=",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -4113,6 +4231,57 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/data-view-buffer": {
+      "version": "1.0.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/data-view-buffer/-/data-view-buffer-1.0.1.tgz",
+      "integrity": "sha1-jqYybv7Bei5CYgaW5nHX1ai8ZrI=",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.6",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/data-view-byte-length": {
+      "version": "1.0.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/data-view-byte-length/-/data-view-byte-length-1.0.1.tgz",
+      "integrity": "sha1-kHIcqV/ygGd+t5N0n84QETR2aeI=",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/data-view-byte-offset": {
+      "version": "1.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/data-view-byte-offset/-/data-view-byte-offset-1.0.0.tgz",
+      "integrity": "sha1-Xgu/tIKO0tG5tADNin0Rm8oP8Yo=",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.6",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/date-utils": {
       "version": "1.2.21",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/date-utils/-/date-utils-1.2.21.tgz",
@@ -4189,17 +4358,20 @@
       }
     },
     "node_modules/define-data-property": {
-      "version": "1.1.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/define-data-property/-/define-data-property-1.1.1.tgz",
-      "integrity": "sha1-w1980KsJiDSA0SrFyyE3FVh4ALM=",
+      "version": "1.1.4",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha1-iU3BQbt9MGCuQ2b2oBB+aPvkjF4=",
       "license": "MIT",
       "dependencies": {
-        "get-intrinsic": "^1.2.1",
-        "gopd": "^1.0.1",
-        "has-property-descriptors": "^1.0.0"
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/define-lazy-prop": {
@@ -4296,9 +4468,9 @@
       }
     },
     "node_modules/diagnostic-channel-publishers": {
-      "version": "1.0.7",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/diagnostic-channel-publishers/-/diagnostic-channel-publishers-1.0.7.tgz",
-      "integrity": "sha1-m3+NXuEpVIGu4ZyCfZF+lv7fLEo=",
+      "version": "1.0.8",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/diagnostic-channel-publishers/-/diagnostic-channel-publishers-1.0.8.tgz",
+      "integrity": "sha1-cAVXqQLEQ8sR+Znxn1CouzvkkKA=",
       "license": "MIT",
       "peerDependencies": {
         "diagnostic-channel": "*"
@@ -4405,9 +4577,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.587",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/electron-to-chromium/-/electron-to-chromium-1.4.587.tgz",
-      "integrity": "sha1-2Lhk8hM4tgeY1Eej2DuQdT9wHQc=",
+      "version": "1.4.729",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/electron-to-chromium/-/electron-to-chromium-1.4.729.tgz",
+      "integrity": "sha1-hHfSHipQmTeBlQiFsnMdkq1TLAA=",
       "dev": true,
       "license": "ISC"
     },
@@ -4483,50 +4655,57 @@
       }
     },
     "node_modules/es-abstract": {
-      "version": "1.22.3",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/es-abstract/-/es-abstract-1.22.3.tgz",
-      "integrity": "sha1-SOefVXMZjebe41iRlXJ/T3S8TzI=",
+      "version": "1.23.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/es-abstract/-/es-abstract-1.23.3.tgz",
+      "integrity": "sha1-jwxaNc0hUxJXPFonyH39bIgaCqA=",
       "license": "MIT",
       "dependencies": {
-        "array-buffer-byte-length": "^1.0.0",
-        "arraybuffer.prototype.slice": "^1.0.2",
-        "available-typed-arrays": "^1.0.5",
-        "call-bind": "^1.0.5",
-        "es-set-tostringtag": "^2.0.1",
+        "array-buffer-byte-length": "^1.0.1",
+        "arraybuffer.prototype.slice": "^1.0.3",
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.7",
+        "data-view-buffer": "^1.0.1",
+        "data-view-byte-length": "^1.0.1",
+        "data-view-byte-offset": "^1.0.0",
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "es-set-tostringtag": "^2.0.3",
         "es-to-primitive": "^1.2.1",
         "function.prototype.name": "^1.1.6",
-        "get-intrinsic": "^1.2.2",
-        "get-symbol-description": "^1.0.0",
+        "get-intrinsic": "^1.2.4",
+        "get-symbol-description": "^1.0.2",
         "globalthis": "^1.0.3",
         "gopd": "^1.0.1",
-        "has-property-descriptors": "^1.0.0",
-        "has-proto": "^1.0.1",
+        "has-property-descriptors": "^1.0.2",
+        "has-proto": "^1.0.3",
         "has-symbols": "^1.0.3",
-        "hasown": "^2.0.0",
-        "internal-slot": "^1.0.5",
-        "is-array-buffer": "^3.0.2",
+        "hasown": "^2.0.2",
+        "internal-slot": "^1.0.7",
+        "is-array-buffer": "^3.0.4",
         "is-callable": "^1.2.7",
-        "is-negative-zero": "^2.0.2",
+        "is-data-view": "^1.0.1",
+        "is-negative-zero": "^2.0.3",
         "is-regex": "^1.1.4",
-        "is-shared-array-buffer": "^1.0.2",
+        "is-shared-array-buffer": "^1.0.3",
         "is-string": "^1.0.7",
-        "is-typed-array": "^1.1.12",
+        "is-typed-array": "^1.1.13",
         "is-weakref": "^1.0.2",
         "object-inspect": "^1.13.1",
         "object-keys": "^1.1.1",
-        "object.assign": "^4.1.4",
-        "regexp.prototype.flags": "^1.5.1",
-        "safe-array-concat": "^1.0.1",
-        "safe-regex-test": "^1.0.0",
-        "string.prototype.trim": "^1.2.8",
-        "string.prototype.trimend": "^1.0.7",
-        "string.prototype.trimstart": "^1.0.7",
-        "typed-array-buffer": "^1.0.0",
-        "typed-array-byte-length": "^1.0.0",
-        "typed-array-byte-offset": "^1.0.0",
-        "typed-array-length": "^1.0.4",
+        "object.assign": "^4.1.5",
+        "regexp.prototype.flags": "^1.5.2",
+        "safe-array-concat": "^1.1.2",
+        "safe-regex-test": "^1.0.3",
+        "string.prototype.trim": "^1.2.9",
+        "string.prototype.trimend": "^1.0.8",
+        "string.prototype.trimstart": "^1.0.8",
+        "typed-array-buffer": "^1.0.2",
+        "typed-array-byte-length": "^1.0.1",
+        "typed-array-byte-offset": "^1.0.2",
+        "typed-array-length": "^1.0.6",
         "unbox-primitive": "^1.0.2",
-        "which-typed-array": "^1.1.13"
+        "which-typed-array": "^1.1.15"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4536,19 +4715,19 @@
       }
     },
     "node_modules/es-aggregate-error": {
-      "version": "1.0.11",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/es-aggregate-error/-/es-aggregate-error-1.0.11.tgz",
-      "integrity": "sha1-AT1rIFoYdQROjduFkqqL1bbLIcU=",
+      "version": "1.0.13",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/es-aggregate-error/-/es-aggregate-error-1.0.13.tgz",
+      "integrity": "sha1-fyi3fJ2NCbvNOkZuS+n+AvqYUgE=",
       "license": "MIT",
       "dependencies": {
-        "define-data-property": "^1.1.0",
+        "define-data-property": "^1.1.4",
         "define-properties": "^1.2.1",
-        "es-abstract": "^1.22.1",
-        "function-bind": "^1.1.1",
-        "get-intrinsic": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
         "globalthis": "^1.0.3",
-        "has-property-descriptors": "^1.0.0",
-        "set-function-name": "^2.0.1"
+        "has-property-descriptors": "^1.0.2",
+        "set-function-name": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4557,15 +4736,48 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/es-set-tostringtag": {
-      "version": "2.0.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/es-set-tostringtag/-/es-set-tostringtag-2.0.2.tgz",
-      "integrity": "sha1-EffMn2M3aTCl8gvkkVg09Lx0+ck=",
+    "node_modules/es-define-property": {
+      "version": "1.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/es-define-property/-/es-define-property-1.0.0.tgz",
+      "integrity": "sha1-x/rvvf+LJpbPX0aSHt+3fMS6OEU=",
       "license": "MIT",
       "dependencies": {
-        "get-intrinsic": "^1.2.2",
-        "has-tostringtag": "^1.0.0",
-        "hasown": "^2.0.0"
+        "get-intrinsic": "^1.2.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha1-BfdaJdq5jk+x3NXhRywFRtUFfI8=",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/es-object-atoms/-/es-object-atoms-1.0.0.tgz",
+      "integrity": "sha1-3bVc1HrC4kBwEmC8Ko4x7LZD2UE=",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.0.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/es-set-tostringtag/-/es-set-tostringtag-2.0.3.tgz",
+      "integrity": "sha1-i7YPCkQMLkKBliQoQ41YVFrzl3c=",
+      "license": "MIT",
+      "dependencies": {
+        "get-intrinsic": "^1.2.4",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4605,9 +4817,9 @@
       "license": "MIT"
     },
     "node_modules/escalade": {
-      "version": "3.1.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/escalade/-/escalade-3.1.1.tgz",
-      "integrity": "sha1-2M/ccACWXFoBdLSoLqpcBVJ0LkA=",
+      "version": "3.1.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/escalade/-/escalade-3.1.2.tgz",
+      "integrity": "sha1-VAdumrKepb89jx7WKs/7uIJy3yc=",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -4632,16 +4844,16 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.53.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/eslint/-/eslint-8.53.0.tgz",
-      "integrity": "sha1-FPLIJEKY/K4fRpRUWVd0E7oml84=",
+      "version": "8.57.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/eslint/-/eslint-8.57.0.tgz",
+      "integrity": "sha1-x4am/Q4LaJQar2JFlvuYcIkZVmg=",
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
-        "@eslint/eslintrc": "^2.1.3",
-        "@eslint/js": "8.53.0",
-        "@humanwhocodes/config-array": "^0.11.13",
+        "@eslint/eslintrc": "^2.1.4",
+        "@eslint/js": "8.57.0",
+        "@humanwhocodes/config-array": "^0.11.14",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
         "@ungap/structured-clone": "^1.2.0",
@@ -4746,9 +4958,9 @@
       "license": "MIT"
     },
     "node_modules/eslint-module-utils": {
-      "version": "2.8.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/eslint-module-utils/-/eslint-module-utils-2.8.0.tgz",
-      "integrity": "sha1-5Dn+5l/DP2u6Yw/2Ie/DjsA3XEk=",
+      "version": "2.8.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/eslint-module-utils/-/eslint-module-utils-2.8.1.tgz",
+      "integrity": "sha1-UvJAQwDDvTPe7OnXNy+zN8wdfDQ=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4781,9 +4993,9 @@
       "license": "MIT"
     },
     "node_modules/eslint-plugin-import": {
-      "version": "2.29.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/eslint-plugin-import/-/eslint-plugin-import-2.29.0.tgz",
-      "integrity": "sha1-gTMjLkMp7jRPL2Eohawwc7C34VU=",
+      "version": "2.29.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/eslint-plugin-import/-/eslint-plugin-import-2.29.1.tgz",
+      "integrity": "sha1-1Fs3te9ZAdY5wVJw101G0WEVBkM=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4803,7 +5015,7 @@
         "object.groupby": "^1.0.1",
         "object.values": "^1.1.7",
         "semver": "^6.3.1",
-        "tsconfig-paths": "^3.14.2"
+        "tsconfig-paths": "^3.15.0"
       },
       "engines": {
         "node": ">=4"
@@ -5074,17 +5286,17 @@
       }
     },
     "node_modules/express": {
-      "version": "4.18.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/express/-/express-4.18.2.tgz",
-      "integrity": "sha1-P6vggpbpMMeWwZ48UWl5OGup/Vk=",
+      "version": "4.19.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/express/-/express-4.19.2.tgz",
+      "integrity": "sha1-4lQ3gno6p/KoJ7yBcbu7Zko1ZGU=",
       "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "1.20.1",
+        "body-parser": "1.20.2",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.5.0",
+        "cookie": "0.6.0",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",
@@ -5126,45 +5338,6 @@
       },
       "engines": {
         "node": ">= 8.0.0"
-      }
-    },
-    "node_modules/express/node_modules/body-parser": {
-      "version": "1.20.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/body-parser/-/body-parser-1.20.1.tgz",
-      "integrity": "sha1-sYEqiRLBlc03Gj7l5m+qIzilxmg=",
-      "license": "MIT",
-      "dependencies": {
-        "bytes": "3.1.2",
-        "content-type": "~1.0.4",
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "destroy": "1.2.0",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "on-finished": "2.4.1",
-        "qs": "6.11.0",
-        "raw-body": "2.5.1",
-        "type-is": "~1.6.18",
-        "unpipe": "1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8",
-        "npm": "1.2.8000 || >= 1.4.16"
-      }
-    },
-    "node_modules/express/node_modules/raw-body": {
-      "version": "2.5.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/raw-body/-/raw-body-2.5.1.tgz",
-      "integrity": "sha1-/hsWKLGBtwAhXl/UI4n5i3E5KFc=",
-      "license": "MIT",
-      "dependencies": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "unpipe": "1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
       }
     },
     "node_modules/extend": {
@@ -5222,9 +5395,9 @@
       "license": "MIT"
     },
     "node_modules/fastq": {
-      "version": "1.15.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/fastq/-/fastq-1.15.0.tgz",
-      "integrity": "sha1-0E0HxqKmj+RZn+qNLhA6k3+uazo=",
+      "version": "1.17.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/fastq/-/fastq-1.17.1.tgz",
+      "integrity": "sha1-KlI/B6TnsegaQrkbi/IlQQd1O0c=",
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
@@ -5374,9 +5547,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.2.9",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/flatted/-/flatted-3.2.9.tgz",
-      "integrity": "sha1-frTGfKG6NCMsqdLZPpiG5hGtfa8=",
+      "version": "3.3.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/flatted/-/flatted-3.3.1.tgz",
+      "integrity": "sha1-IdtHBymmc01JlwAvQ5yzCJh/Vno=",
       "license": "ISC"
     },
     "node_modules/fn.name": {
@@ -5386,9 +5559,9 @@
       "license": "MIT"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.3",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/follow-redirects/-/follow-redirects-1.15.3.tgz",
-      "integrity": "sha1-/i8+8mkK/OfoLtC0TbCBZbIHEjo=",
+      "version": "1.15.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha1-f4FcDNpCScdP8J6V75fCO1/QOZs=",
       "funding": [
         {
           "type": "individual",
@@ -5553,15 +5726,19 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.2.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/get-intrinsic/-/get-intrinsic-1.2.2.tgz",
-      "integrity": "sha1-KBt2IpcRI+HvSzyQ/XU5MG2pPzs=",
+      "version": "1.2.4",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
+      "integrity": "sha1-44X1pLUifUScPqu60FSU7wq76t0=",
       "license": "MIT",
       "dependencies": {
+        "es-errors": "^1.3.0",
         "function-bind": "^1.1.2",
         "has-proto": "^1.0.1",
         "has-symbols": "^1.0.3",
         "hasown": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -5591,13 +5768,14 @@
       }
     },
     "node_modules/get-symbol-description": {
-      "version": "1.0.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
-      "integrity": "sha1-f9uByQAQH71WTdXxowr1qtweWNY=",
+      "version": "1.0.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/get-symbol-description/-/get-symbol-description-1.0.2.tgz",
+      "integrity": "sha1-UzdE1aogrKTgecjl2vf9RCAoIfU=",
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "get-intrinsic": "^1.1.1"
+        "call-bind": "^1.0.5",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5648,9 +5826,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "13.23.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/globals/-/globals-13.23.0.tgz",
-      "integrity": "sha1-7zFnPJJqCXbh9h2rTcpX4MCorwI=",
+      "version": "13.24.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/globals/-/globals-13.24.0.tgz",
+      "integrity": "sha1-hDKhnXjODB6DOUnDats0VAC7EXE=",
       "license": "MIT",
       "dependencies": {
         "type-fest": "^0.20.2"
@@ -5742,21 +5920,21 @@
       }
     },
     "node_modules/has-property-descriptors": {
-      "version": "1.0.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/has-property-descriptors/-/has-property-descriptors-1.0.1.tgz",
-      "integrity": "sha1-UrowtsXsh/2J+ldLwcORJcb2U0A=",
+      "version": "1.0.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha1-lj7X0HHce/XwhMW/vg0bYiJYaFQ=",
       "license": "MIT",
       "dependencies": {
-        "get-intrinsic": "^1.2.2"
+        "es-define-property": "^1.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/has-proto": {
-      "version": "1.0.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/has-proto/-/has-proto-1.0.1.tgz",
-      "integrity": "sha1-GIXBMFU4lYr/Rp/vN5N8InlUCOA=",
+      "version": "1.0.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/has-proto/-/has-proto-1.0.3.tgz",
+      "integrity": "sha1-sx3f6bDm6ZFFNqarKGQm0CFPd/0=",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5778,12 +5956,12 @@
       }
     },
     "node_modules/has-tostringtag": {
-      "version": "1.0.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
-      "integrity": "sha1-fhM4GKfTlHNPlB5zw9P5KR5liyU=",
+      "version": "1.0.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha1-LNxC1AvvLltO6rfAGnPFTOerWrw=",
       "license": "MIT",
       "dependencies": {
-        "has-symbols": "^1.0.2"
+        "has-symbols": "^1.0.3"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5793,9 +5971,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/hasown/-/hasown-2.0.0.tgz",
-      "integrity": "sha1-9MUT1FSle3x+FlB3jeImsRcAVGw=",
+      "version": "2.0.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha1-AD6vkb563DcuhOxZ3DclLO24AAM=",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -5997,9 +6175,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/ignore": {
-      "version": "5.3.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ignore/-/ignore-5.3.0.tgz",
-      "integrity": "sha1-Z0GK5A001pmclf9WAWdZxxjIL3g=",
+      "version": "5.3.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ignore/-/ignore-5.3.1.tgz",
+      "integrity": "sha1-UHPlVM1CxbM7OUN19Ti4WT401O8=",
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -6119,12 +6297,12 @@
       }
     },
     "node_modules/internal-slot": {
-      "version": "1.0.6",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/internal-slot/-/internal-slot-1.0.6.tgz",
-      "integrity": "sha1-N+dWCYxJEcXpErjtv3HtOqEW+TA=",
+      "version": "1.0.7",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/internal-slot/-/internal-slot-1.0.7.tgz",
+      "integrity": "sha1-wG3Mo+2HQkmIEAewpVI7FyoZCAI=",
       "license": "MIT",
       "dependencies": {
-        "get-intrinsic": "^1.2.2",
+        "es-errors": "^1.3.0",
         "hasown": "^2.0.0",
         "side-channel": "^1.0.4"
       },
@@ -6198,14 +6376,16 @@
       }
     },
     "node_modules/is-array-buffer": {
-      "version": "3.0.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-array-buffer/-/is-array-buffer-3.0.2.tgz",
-      "integrity": "sha1-8mU87YQSCBY47LDrvQxBxuCuy74=",
+      "version": "3.0.4",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-array-buffer/-/is-array-buffer-3.0.4.tgz",
+      "integrity": "sha1-eh+Ss9Ye3SvGXSTxMFMOqT1/rpg=",
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
-        "get-intrinsic": "^1.2.0",
-        "is-typed-array": "^1.1.10"
+        "get-intrinsic": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -6314,6 +6494,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-data-view": {
+      "version": "1.0.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-data-view/-/is-data-view-1.0.1.tgz",
+      "integrity": "sha1-S006URtw89wm1CwDypylFdhHdZ8=",
+      "license": "MIT",
+      "dependencies": {
+        "is-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-date-object": {
       "version": "1.0.5",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-date-object/-/is-date-object-1.0.5.tgz",
@@ -6407,9 +6602,9 @@
       }
     },
     "node_modules/is-negative-zero": {
-      "version": "2.0.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
-      "integrity": "sha1-e/bwOigAO4s5Zd46wm9mTXZfMVA=",
+      "version": "2.0.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
+      "integrity": "sha1-ztkDoCespjgbd3pXQwadc3akl0c=",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -6475,12 +6670,15 @@
       }
     },
     "node_modules/is-shared-array-buffer": {
-      "version": "1.0.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
-      "integrity": "sha1-jyWcVztgtqMtQFihoHQwwKc0THk=",
+      "version": "1.0.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-shared-array-buffer/-/is-shared-array-buffer-1.0.3.tgz",
+      "integrity": "sha1-Ejfxy6BZzbYkMdN43MN9loAYFog=",
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2"
+        "call-bind": "^1.0.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -6529,12 +6727,12 @@
       }
     },
     "node_modules/is-typed-array": {
-      "version": "1.1.12",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-typed-array/-/is-typed-array-1.1.12.tgz",
-      "integrity": "sha1-0Lq1aG70p296cwl7lUcKsZnFfUo=",
+      "version": "1.1.13",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-typed-array/-/is-typed-array-1.1.13.tgz",
+      "integrity": "sha1-1sXKVt9iM0lZMi19fdHMpQ3r4ik=",
       "license": "MIT",
       "dependencies": {
-        "which-typed-array": "^1.1.11"
+        "which-typed-array": "^1.1.14"
       },
       "engines": {
         "node": ">= 0.4"
@@ -6608,15 +6806,15 @@
       }
     },
     "node_modules/istanbul-lib-instrument": {
-      "version": "6.0.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.1.tgz",
-      "integrity": "sha1-ceh3B+gEFChzJRjG+1IRdhdT+98=",
+      "version": "6.0.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.2.tgz",
+      "integrity": "sha1-kWVZNs9zgOTkczgwgeOEeLaZk7E=",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@babel/core": "^7.12.3",
-        "@babel/parser": "^7.14.7",
-        "@istanbuljs/schema": "^0.1.2",
+        "@babel/core": "^7.23.9",
+        "@babel/parser": "^7.23.9",
+        "@istanbuljs/schema": "^0.1.3",
         "istanbul-lib-coverage": "^3.2.0",
         "semver": "^7.5.4"
       },
@@ -6680,9 +6878,9 @@
       "license": "MIT"
     },
     "node_modules/istanbul-reports": {
-      "version": "3.1.6",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/istanbul-reports/-/istanbul-reports-3.1.6.tgz",
-      "integrity": "sha1-JUS8q0doFUKBovCHBHGQJwTMqho=",
+      "version": "3.1.7",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/istanbul-reports/-/istanbul-reports-3.1.7.tgz",
+      "integrity": "sha1-2u0SueHcpRjhXAVuHlN+dBKA+gs=",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -8736,17 +8934,18 @@
       }
     },
     "node_modules/login.dfe.audit.winston-sequelize-transport/node_modules/@js-joda/core": {
-      "version": "5.6.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@js-joda/core/-/core-5.6.1.tgz",
-      "integrity": "sha1-A+JFPYd7YcP1k88DH9GLN1vVSLY=",
+      "version": "5.6.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@js-joda/core/-/core-5.6.2.tgz",
+      "integrity": "sha1-GIXRDapATOor1VV1+RCrO75sM9c=",
       "license": "BSD-3-Clause"
     },
     "node_modules/login.dfe.audit.winston-sequelize-transport/node_modules/bl": {
-      "version": "6.0.8",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/bl/-/bl-6.0.8.tgz",
-      "integrity": "sha1-c31X8tHiW5ykXg9MXYRAlzGobAQ=",
+      "version": "6.0.12",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/bl/-/bl-6.0.12.tgz",
+      "integrity": "sha1-d8NbluE67/AoSWx5i3U4nd7px/g=",
       "license": "MIT",
       "dependencies": {
+        "@types/readable-stream": "^4.0.0",
         "buffer": "^6.0.3",
         "inherits": "^2.0.4",
         "readable-stream": "^4.2.0"
@@ -8827,9 +9026,9 @@
       "license": "MIT"
     },
     "node_modules/login.dfe.audit.winston-sequelize-transport/node_modules/readable-stream": {
-      "version": "4.4.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/readable-stream/-/readable-stream-4.4.2.tgz",
-      "integrity": "sha1-5qztJ607nXJtgwhRW5obmNwbnRM=",
+      "version": "4.5.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/readable-stream/-/readable-stream-4.5.2.tgz",
+      "integrity": "sha1-nn/ExFCZuu7ZNL/265e6bPJyngk=",
       "license": "MIT",
       "dependencies": {
         "abort-controller": "^3.0.0",
@@ -8849,9 +9048,9 @@
       "license": "MIT"
     },
     "node_modules/login.dfe.audit.winston-sequelize-transport/node_modules/sequelize": {
-      "version": "6.35.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/sequelize/-/sequelize-6.35.0.tgz",
-      "integrity": "sha1-cKH6KK/3NAPOhcHaEVXG+FGojCo=",
+      "version": "6.37.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/sequelize/-/sequelize-6.37.2.tgz",
+      "integrity": "sha1-+YBS+BxAwmuoU4L8s15zRjCFQvQ=",
       "funding": [
         {
           "type": "opencollective",
@@ -8938,12 +9137,12 @@
       }
     },
     "node_modules/login.dfe.audit.winston-sequelize-transport/node_modules/tedious": {
-      "version": "16.6.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/tedious/-/tedious-16.6.0.tgz",
-      "integrity": "sha1-Nd7ntOptlNRi2kZhsX8LraGVmFw=",
+      "version": "16.7.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/tedious/-/tedious-16.7.1.tgz",
+      "integrity": "sha1-EZDzD9maQT8dySUN7kg1zweItlA=",
       "license": "MIT",
       "dependencies": {
-        "@azure/identity": "^2.0.4",
+        "@azure/identity": "^3.4.1",
         "@azure/keyvault-keys": "^4.4.0",
         "@js-joda/core": "^5.5.3",
         "bl": "^6.0.3",
@@ -8953,7 +9152,6 @@
         "jsbi": "^4.3.0",
         "native-duplexpair": "^1.0.0",
         "node-abort-controller": "^3.1.1",
-        "punycode": "^2.3.0",
         "sprintf-js": "^1.1.2"
       },
       "engines": {
@@ -8997,17 +9195,18 @@
       }
     },
     "node_modules/login.dfe.dao/node_modules/@js-joda/core": {
-      "version": "5.6.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@js-joda/core/-/core-5.6.1.tgz",
-      "integrity": "sha1-A+JFPYd7YcP1k88DH9GLN1vVSLY=",
+      "version": "5.6.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@js-joda/core/-/core-5.6.2.tgz",
+      "integrity": "sha1-GIXRDapATOor1VV1+RCrO75sM9c=",
       "license": "BSD-3-Clause"
     },
     "node_modules/login.dfe.dao/node_modules/bl": {
-      "version": "6.0.8",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/bl/-/bl-6.0.8.tgz",
-      "integrity": "sha1-c31X8tHiW5ykXg9MXYRAlzGobAQ=",
+      "version": "6.0.12",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/bl/-/bl-6.0.12.tgz",
+      "integrity": "sha1-d8NbluE67/AoSWx5i3U4nd7px/g=",
       "license": "MIT",
       "dependencies": {
+        "@types/readable-stream": "^4.0.0",
         "buffer": "^6.0.3",
         "inherits": "^2.0.4",
         "readable-stream": "^4.2.0"
@@ -9088,9 +9287,9 @@
       "license": "MIT"
     },
     "node_modules/login.dfe.dao/node_modules/readable-stream": {
-      "version": "4.4.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/readable-stream/-/readable-stream-4.4.2.tgz",
-      "integrity": "sha1-5qztJ607nXJtgwhRW5obmNwbnRM=",
+      "version": "4.5.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/readable-stream/-/readable-stream-4.5.2.tgz",
+      "integrity": "sha1-nn/ExFCZuu7ZNL/265e6bPJyngk=",
       "license": "MIT",
       "dependencies": {
         "abort-controller": "^3.0.0",
@@ -9110,9 +9309,9 @@
       "license": "MIT"
     },
     "node_modules/login.dfe.dao/node_modules/sequelize": {
-      "version": "6.35.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/sequelize/-/sequelize-6.35.0.tgz",
-      "integrity": "sha1-cKH6KK/3NAPOhcHaEVXG+FGojCo=",
+      "version": "6.37.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/sequelize/-/sequelize-6.37.2.tgz",
+      "integrity": "sha1-+YBS+BxAwmuoU4L8s15zRjCFQvQ=",
       "funding": [
         {
           "type": "opencollective",
@@ -9199,12 +9398,12 @@
       }
     },
     "node_modules/login.dfe.dao/node_modules/tedious": {
-      "version": "16.6.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/tedious/-/tedious-16.6.0.tgz",
-      "integrity": "sha1-Nd7ntOptlNRi2kZhsX8LraGVmFw=",
+      "version": "16.7.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/tedious/-/tedious-16.7.1.tgz",
+      "integrity": "sha1-EZDzD9maQT8dySUN7kg1zweItlA=",
       "license": "MIT",
       "dependencies": {
-        "@azure/identity": "^2.0.4",
+        "@azure/identity": "^3.4.1",
         "@azure/keyvault-keys": "^4.4.0",
         "@js-joda/core": "^5.5.3",
         "bl": "^6.0.3",
@@ -9214,7 +9413,6 @@
         "jsbi": "^4.3.0",
         "native-duplexpair": "^1.0.0",
         "node-abort-controller": "^3.1.1",
-        "punycode": "^2.3.0",
         "sprintf-js": "^1.1.2"
       },
       "engines": {
@@ -9289,9 +9487,9 @@
       "license": "MIT"
     },
     "node_modules/login.dfe.healthcheck/node_modules/sequelize": {
-      "version": "6.35.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/sequelize/-/sequelize-6.35.0.tgz",
-      "integrity": "sha1-cKH6KK/3NAPOhcHaEVXG+FGojCo=",
+      "version": "6.37.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/sequelize/-/sequelize-6.37.2.tgz",
+      "integrity": "sha1-+YBS+BxAwmuoU4L8s15zRjCFQvQ=",
       "funding": [
         {
           "type": "opencollective",
@@ -9446,8 +9644,8 @@
       }
     },
     "node_modules/login.dfe.request-promise-retry": {
-      "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/DFE-Digital/login.dfe.request-promise-retry.git#cedf7a91a4c7e1d51f51389c4ff3c2aa4273aa1d",
+      "version": "3.1.0",
+      "resolved": "git+ssh://git@github.com/DFE-Digital/login.dfe.request-promise-retry.git#c6cb2494c9dce08cc41bdcbe3d999059c3a13237",
       "license": "MIT",
       "dependencies": {
         "login.dfe.async-retry": "git+https://github.com/DFE-Digital/login.dfe.async-retry.git#v2.0.0",
@@ -9660,18 +9858,18 @@
       "license": "MIT"
     },
     "node_modules/moment": {
-      "version": "2.29.4",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/moment/-/moment-2.29.4.tgz",
-      "integrity": "sha1-Pb4FKIn+fBsu2Wb8s6dzKJZO8Qg=",
+      "version": "2.30.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha1-+MkcB7enhuMMWZJt9TC06slpdK4=",
       "license": "MIT",
       "engines": {
         "node": "*"
       }
     },
     "node_modules/moment-timezone": {
-      "version": "0.5.43",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/moment-timezone/-/moment-timezone-0.5.43.tgz",
-      "integrity": "sha1-Pdfz0MZ/eMI80ZBrmyE3oJs8R5A=",
+      "version": "0.5.45",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/moment-timezone/-/moment-timezone-0.5.45.tgz",
+      "integrity": "sha1-y2hazVa6wQ5p2TxTY2brZaprz1w=",
       "license": "MIT",
       "dependencies": {
         "moment": "^2.29.4"
@@ -9846,9 +10044,9 @@
       }
     },
     "node_modules/nan": {
-      "version": "2.18.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/nan/-/nan-2.18.0.tgz",
-      "integrity": "sha1-Jqb6rn/76yk6OWYOiKdrguMLdVQ=",
+      "version": "2.19.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/nan/-/nan-2.19.0.tgz",
+      "integrity": "sha1-u1gSKtVabFvJczA5CNWxbP3VqMA=",
       "license": "MIT",
       "optional": true
     },
@@ -10090,12 +10288,14 @@
       "license": "Apache-2.0"
     },
     "node_modules/node-mocks-http": {
-      "version": "1.13.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/node-mocks-http/-/node-mocks-http-1.13.0.tgz",
-      "integrity": "sha1-OdcVSYG5b9A9Mj9q9ZTLVyX3flQ=",
+      "version": "1.14.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/node-mocks-http/-/node-mocks-http-1.14.1.tgz",
+      "integrity": "sha1-ajh84JIp/lRdzAFU0WvDSAYY4BM=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@types/express": "^4.17.21",
+        "@types/node": "^20.10.6",
         "accepts": "^1.3.7",
         "content-disposition": "^0.5.3",
         "depd": "^1.1.0",
@@ -10168,21 +10368,21 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.13",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/node-releases/-/node-releases-2.0.13.tgz",
-      "integrity": "sha1-1e0WJ8I+NGHoGbAuV7deSJmxyB0=",
+      "version": "2.0.14",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/node-releases/-/node-releases-2.0.14.tgz",
+      "integrity": "sha1-L/sFO864sr6Elezhq2zmAMRGGws=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/nodemon": {
-      "version": "3.0.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/nodemon/-/nodemon-3.0.1.tgz",
-      "integrity": "sha1-r/6CKixfITVEZrL8iugyd9J9rcc=",
+      "version": "3.1.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/nodemon/-/nodemon-3.1.0.tgz",
+      "integrity": "sha1-/3OU8kUOtqXpb+QYCs1RdrKXmck=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "chokidar": "^3.5.2",
-        "debug": "^3.2.7",
+        "debug": "^4",
         "ignore-by-default": "^1.0.1",
         "minimatch": "^3.1.2",
         "pstree.remy": "^1.1.8",
@@ -10204,13 +10404,21 @@
       }
     },
     "node_modules/nodemon/node_modules/debug": {
-      "version": "3.2.7",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha1-clgLfpFF+zm2Z2+cXl+xALk0F5o=",
+      "version": "4.3.4",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha1-Exn2V5NX8jONMzfSzdSRS7XcyGU=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ms": "^2.1.1"
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/nodemon/node_modules/has-flag": {
@@ -10224,9 +10432,9 @@
       }
     },
     "node_modules/nodemon/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI=",
+      "version": "2.1.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
       "dev": true,
       "license": "MIT"
     },
@@ -10352,13 +10560,13 @@
       }
     },
     "node_modules/object.assign": {
-      "version": "4.1.4",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/object.assign/-/object.assign-4.1.4.tgz",
-      "integrity": "sha1-lnPHx8NRq4xNC1FvQ0Pr9N+3eZ8=",
+      "version": "4.1.5",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/object.assign/-/object.assign-4.1.5.tgz",
+      "integrity": "sha1-OoM/mrf9uA/J6NIwDIA9IW2P27A=",
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
+        "call-bind": "^1.0.5",
+        "define-properties": "^1.2.1",
         "has-symbols": "^1.0.3",
         "object-keys": "^1.1.1"
       },
@@ -10370,30 +10578,31 @@
       }
     },
     "node_modules/object.entries": {
-      "version": "1.1.7",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/object.entries/-/object.entries-1.1.7.tgz",
-      "integrity": "sha1-K0d2DiouOnUvOd2HRlXGGn8DwTE=",
+      "version": "1.1.8",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/object.entries/-/object.entries-1.1.8.tgz",
+      "integrity": "sha1-v/5vKC4B9NF4ByBKJPjt2CNZnEE=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "es-abstract": "^1.22.1"
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
       },
       "engines": {
         "node": ">= 0.4"
       }
     },
     "node_modules/object.fromentries": {
-      "version": "2.0.7",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/object.fromentries/-/object.fromentries-2.0.7.tgz",
-      "integrity": "sha1-celfRB6aDqa69oLsqvN/oqjX5hY=",
+      "version": "2.0.8",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/object.fromentries/-/object.fromentries-2.0.8.tgz",
+      "integrity": "sha1-9xldipuXvZXLwZmeqTns0aKwDGU=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "es-abstract": "^1.22.1"
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-object-atoms": "^1.0.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -10403,28 +10612,30 @@
       }
     },
     "node_modules/object.groupby": {
-      "version": "1.0.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/object.groupby/-/object.groupby-1.0.1.tgz",
-      "integrity": "sha1-1B2fPI1sd42cushrTun1rxAxUu4=",
+      "version": "1.0.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/object.groupby/-/object.groupby-1.0.3.tgz",
+      "integrity": "sha1-mxJcNiOBKfb3thlUoecXYUjVAC4=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "es-abstract": "^1.22.1",
-        "get-intrinsic": "^1.2.1"
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/object.values": {
-      "version": "1.1.7",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/object.values/-/object.values-1.1.7.tgz",
-      "integrity": "sha1-YX7RMnLn4QcbQ5c6oWVdkpG4RCo=",
+      "version": "1.2.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/object.values/-/object.values-1.2.0.tgz",
+      "integrity": "sha1-ZUBanZLO5orC0wMALguEcKTZqxs=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "es-abstract": "^1.22.1"
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -10581,12 +10792,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/packet-reader": {
-      "version": "1.0.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/packet-reader/-/packet-reader-1.0.0.tgz",
-      "integrity": "sha1-kjjlSA3tq6z+H+PydxBj8WQVfXQ=",
-      "license": "MIT"
     },
     "node_modules/pako": {
       "version": "2.1.0",
@@ -10747,16 +10952,14 @@
       "license": "MIT"
     },
     "node_modules/pg": {
-      "version": "8.11.3",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/pg/-/pg-8.11.3.tgz",
-      "integrity": "sha1-19tuP+Jo/O3WW45Fmc2guLS/dss=",
+      "version": "8.11.5",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/pg/-/pg-8.11.5.tgz",
+      "integrity": "sha1-5yKwpfHtkpMcMXWOvsPd+HjdQSg=",
       "license": "MIT",
       "dependencies": {
-        "buffer-writer": "2.0.0",
-        "packet-reader": "1.0.0",
-        "pg-connection-string": "^2.6.2",
-        "pg-pool": "^3.6.1",
-        "pg-protocol": "^1.6.0",
+        "pg-connection-string": "^2.6.4",
+        "pg-pool": "^3.6.2",
+        "pg-protocol": "^1.6.1",
         "pg-types": "^2.1.0",
         "pgpass": "1.x"
       },
@@ -10783,9 +10986,9 @@
       "optional": true
     },
     "node_modules/pg-connection-string": {
-      "version": "2.6.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/pg-connection-string/-/pg-connection-string-2.6.2.tgz",
-      "integrity": "sha1-cT2CBT3k4r0Wb6twzU8mrTaqtHU=",
+      "version": "2.6.4",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/pg-connection-string/-/pg-connection-string-2.6.4.tgz",
+      "integrity": "sha1-9UOGKt+kn6ThS8ioiS0qhNdUJG0=",
       "license": "MIT"
     },
     "node_modules/pg-int8": {
@@ -10798,18 +11001,18 @@
       }
     },
     "node_modules/pg-pool": {
-      "version": "3.6.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/pg-pool/-/pg-pool-3.6.1.tgz",
-      "integrity": "sha1-WpAu2nmo1+PJKLd6v3drPLfTUfc=",
+      "version": "3.6.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/pg-pool/-/pg-pool-3.6.2.tgz",
+      "integrity": "sha1-OlkjcLiuPwKnyBMNJFvAL6LF8/I=",
       "license": "MIT",
       "peerDependencies": {
         "pg": ">=8.0"
       }
     },
     "node_modules/pg-protocol": {
-      "version": "1.6.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/pg-protocol/-/pg-protocol-1.6.0.tgz",
-      "integrity": "sha1-TJFhPAMVNJNjryCEYI24Q1AviDM=",
+      "version": "1.6.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/pg-protocol/-/pg-protocol-1.6.1.tgz",
+      "integrity": "sha1-ITM+bYOwH6rr/nozp61r/Z7TjLM=",
       "license": "MIT"
     },
     "node_modules/pg-types": {
@@ -10841,7 +11044,6 @@
       "version": "1.0.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/picocolors/-/picocolors-1.0.0.tgz",
       "integrity": "sha1-y1vcdP8/UYkiNur3nWi8RFZKuBw=",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -10964,6 +11166,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz",
+      "integrity": "sha1-ibtjxvraLD6QrcSmR77us5zHv48=",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/postgres-array": {
@@ -11271,9 +11482,9 @@
       }
     },
     "node_modules/pure-rand": {
-      "version": "6.0.4",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/pure-rand/-/pure-rand-6.0.4.tgz",
-      "integrity": "sha1-ULc39qklRoZ5v/AK0g6t5T831cc=",
+      "version": "6.1.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/pure-rand/-/pure-rand-6.1.0.tgz",
+      "integrity": "sha1-0XPPIyWCMZdsy9sFJHyXh5V2BPI=",
       "dev": true,
       "funding": [
         {
@@ -11527,14 +11738,15 @@
       "license": "MIT"
     },
     "node_modules/regexp.prototype.flags": {
-      "version": "1.5.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/regexp.prototype.flags/-/regexp.prototype.flags-1.5.1.tgz",
-      "integrity": "sha1-kM6YkTjbIJ+BSS7dc0GDzpn5Z34=",
+      "version": "1.5.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/regexp.prototype.flags/-/regexp.prototype.flags-1.5.2.tgz",
+      "integrity": "sha1-E49kSjNQ+YGoWMRPa7GmH/Wb4zQ=",
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "set-function-name": "^2.0.0"
+        "call-bind": "^1.0.6",
+        "define-properties": "^1.2.1",
+        "es-errors": "^1.3.0",
+        "set-function-name": "^2.0.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -11743,9 +11955,9 @@
       }
     },
     "node_modules/require-in-the-middle": {
-      "version": "7.2.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/require-in-the-middle/-/require-in-the-middle-7.2.0.tgz",
-      "integrity": "sha1-tTnejwCVVETciu2V4XxpsKTxD88=",
+      "version": "7.3.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/require-in-the-middle/-/require-in-the-middle-7.3.0.tgz",
+      "integrity": "sha1-zmShCDZH3AezJzs0g1fvrIqZRck=",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.1.1",
@@ -12016,13 +12228,13 @@
       "license": "0BSD"
     },
     "node_modules/safe-array-concat": {
-      "version": "1.0.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/safe-array-concat/-/safe-array-concat-1.0.1.tgz",
-      "integrity": "sha1-kWhqY8462+oU1hsUyZVyqP+EdUw=",
+      "version": "1.1.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/safe-array-concat/-/safe-array-concat-1.1.2.tgz",
+      "integrity": "sha1-gdd+4MTouGNjUifHISeN1STCDts=",
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "get-intrinsic": "^1.2.1",
+        "call-bind": "^1.0.7",
+        "get-intrinsic": "^1.2.4",
         "has-symbols": "^1.0.3",
         "isarray": "^2.0.5"
       },
@@ -12061,14 +12273,17 @@
       "optional": true
     },
     "node_modules/safe-regex-test": {
-      "version": "1.0.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
-      "integrity": "sha1-eTuHTVJOs2QNGHOq0DWW2y1PIpU=",
+      "version": "1.0.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/safe-regex-test/-/safe-regex-test-1.0.3.tgz",
+      "integrity": "sha1-pbTA8G4KtQ6iw5XBTYNxIykkw3c=",
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "get-intrinsic": "^1.1.3",
+        "call-bind": "^1.0.6",
+        "es-errors": "^1.3.0",
         "is-regex": "^1.1.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -12102,9 +12317,9 @@
       "license": "ISC"
     },
     "node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha1-SDmG7E7TjhxsSMNIlKkYLb/2im4=",
+      "version": "7.6.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha1-Gkak20v/zM2Xt0O1AFyDJfI9Ti0=",
       "license": "ISC",
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -12273,29 +12488,32 @@
       "license": "ISC"
     },
     "node_modules/set-function-length": {
-      "version": "1.1.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/set-function-length/-/set-function-length-1.1.1.tgz",
-      "integrity": "sha1-S8Ofr7AwciSjPhBqfTXKEhjWWe0=",
+      "version": "1.2.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha1-qscjFBmOrtl1z3eyw7a4gGleVEk=",
       "license": "MIT",
       "dependencies": {
-        "define-data-property": "^1.1.1",
-        "get-intrinsic": "^1.2.1",
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
         "gopd": "^1.0.1",
-        "has-property-descriptors": "^1.0.0"
+        "has-property-descriptors": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
       }
     },
     "node_modules/set-function-name": {
-      "version": "2.0.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/set-function-name/-/set-function-name-2.0.1.tgz",
-      "integrity": "sha1-Es44t5VDELn2H6oScBYgoMiCeTo=",
+      "version": "2.0.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/set-function-name/-/set-function-name-2.0.2.tgz",
+      "integrity": "sha1-FqcFxaDcL15jjKltiozU4cK5CYU=",
       "license": "MIT",
       "dependencies": {
-        "define-data-property": "^1.0.1",
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
         "functions-have-names": "^1.2.3",
-        "has-property-descriptors": "^1.0.0"
+        "has-property-descriptors": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -12335,14 +12553,18 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/side-channel": {
-      "version": "1.0.4",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/side-channel/-/side-channel-1.0.4.tgz",
-      "integrity": "sha1-785cj9wQTudRslxY1CkAEfpeos8=",
+      "version": "1.0.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/side-channel/-/side-channel-1.0.6.tgz",
+      "integrity": "sha1-q9Jft80kuvRUZkBrEJa3gxySFfI=",
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.0",
-        "get-intrinsic": "^1.0.2",
-        "object-inspect": "^1.9.0"
+        "call-bind": "^1.0.7",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.4",
+        "object-inspect": "^1.13.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -12355,9 +12577,9 @@
       "license": "ISC"
     },
     "node_modules/simpl-schema": {
-      "version": "3.4.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/simpl-schema/-/simpl-schema-3.4.1.tgz",
-      "integrity": "sha1-kwAGoVDR4ZZFwkHpbaf+B2/iZYM=",
+      "version": "3.4.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/simpl-schema/-/simpl-schema-3.4.6.tgz",
+      "integrity": "sha1-3+v1K1yiY1AxWRXjmU/+vVFbKeY=",
       "license": "MIT",
       "dependencies": {
         "clone": "^2.1.2",
@@ -12513,9 +12735,9 @@
       }
     },
     "node_modules/spdx-exceptions": {
-      "version": "2.3.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
-      "integrity": "sha1-PyjOGnegA3JoPq3kpDMYNSeiFj0=",
+      "version": "2.5.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
+      "integrity": "sha1-XWB9J/yAb2bXtkp2ZlD6iQ8E7WY=",
       "license": "CC-BY-3.0"
     },
     "node_modules/spdx-expression-parse": {
@@ -12529,9 +12751,9 @@
       }
     },
     "node_modules/spdx-license-ids": {
-      "version": "3.0.16",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/spdx-license-ids/-/spdx-license-ids-3.0.16.tgz",
-      "integrity": "sha1-oU9k4JVPbiXMZYe9TzklItsNmY8=",
+      "version": "3.0.17",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/spdx-license-ids/-/spdx-license-ids-3.0.17.tgz",
+      "integrity": "sha1-iH2oqnMhjlGh2RdQLXmGMWGpP5w=",
       "license": "CC0-1.0"
     },
     "node_modules/split2": {
@@ -12695,14 +12917,15 @@
       }
     },
     "node_modules/string.prototype.trim": {
-      "version": "1.2.8",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/string.prototype.trim/-/string.prototype.trim-1.2.8.tgz",
-      "integrity": "sha1-+axvivS9Vd36iJXmrqkqljlTk70=",
+      "version": "1.2.9",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/string.prototype.trim/-/string.prototype.trim-1.2.9.tgz",
+      "integrity": "sha1-tvoybXLSx4tt8C93Wcc/j2J0+qQ=",
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "es-abstract": "^1.22.1"
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.0",
+        "es-object-atoms": "^1.0.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -12712,28 +12935,31 @@
       }
     },
     "node_modules/string.prototype.trimend": {
-      "version": "1.0.7",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/string.prototype.trimend/-/string.prototype.trimend-1.0.7.tgz",
-      "integrity": "sha1-G7OvxQCGYdc+LcAVzUhTcy1sRx4=",
+      "version": "1.0.8",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/string.prototype.trimend/-/string.prototype.trimend-1.0.8.tgz",
+      "integrity": "sha1-NlG4UTcZ6Kn0jefy93ZAsmZSsik=",
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "es-abstract": "^1.22.1"
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/string.prototype.trimstart": {
-      "version": "1.0.7",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/string.prototype.trimstart/-/string.prototype.trimstart-1.0.7.tgz",
-      "integrity": "sha1-1M20S4Okc3/7rC1AbkBdQ9AYQpg=",
+      "version": "1.0.8",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
+      "integrity": "sha1-fug03ajHwX7/MRhHK7Nb/tqjTd4=",
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "es-abstract": "^1.22.1"
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -12905,14 +13131,14 @@
       "license": "MIT"
     },
     "node_modules/supertest": {
-      "version": "6.3.3",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/supertest/-/supertest-6.3.3.tgz",
-      "integrity": "sha1-QvTaGZ/uZWEG/UIsCUz2yVeBQds=",
+      "version": "6.3.4",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/supertest/-/supertest-6.3.4.tgz",
+      "integrity": "sha1-IUXCUFcMLqXTN9s1Utv7eKIoYhg=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "methods": "^1.1.2",
-        "superagent": "^8.0.5"
+        "superagent": "^8.1.2"
       },
       "engines": {
         "node": ">=6.4.0"
@@ -13202,9 +13428,9 @@
       }
     },
     "node_modules/tsconfig-paths": {
-      "version": "3.14.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/tsconfig-paths/-/tsconfig-paths-3.14.2.tgz",
-      "integrity": "sha1-bjLx95QS3s0mH5LWM6ncHPqZ8Ig=",
+      "version": "3.15.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
+      "integrity": "sha1-UpnsYF5VsauyPsk57xXtr0gwcNQ=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13318,29 +13544,30 @@
       }
     },
     "node_modules/typed-array-buffer": {
-      "version": "1.0.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/typed-array-buffer/-/typed-array-buffer-1.0.0.tgz",
-      "integrity": "sha1-GN4+fteXSwpynT/uy5QzjRRyzWA=",
+      "version": "1.0.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/typed-array-buffer/-/typed-array-buffer-1.0.2.tgz",
+      "integrity": "sha1-GGfF2Dsg/LXM8yZJ5eL8dCRHT/M=",
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "get-intrinsic": "^1.2.1",
-        "is-typed-array": "^1.1.10"
+        "call-bind": "^1.0.7",
+        "es-errors": "^1.3.0",
+        "is-typed-array": "^1.1.13"
       },
       "engines": {
         "node": ">= 0.4"
       }
     },
     "node_modules/typed-array-byte-length": {
-      "version": "1.0.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/typed-array-byte-length/-/typed-array-byte-length-1.0.0.tgz",
-      "integrity": "sha1-14eiSplXEWEfsrh6QFJ5lReyMNA=",
+      "version": "1.0.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/typed-array-byte-length/-/typed-array-byte-length-1.0.1.tgz",
+      "integrity": "sha1-2Sly08/5mj+i52Wij83A8did7Gc=",
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
+        "call-bind": "^1.0.7",
         "for-each": "^0.3.3",
-        "has-proto": "^1.0.1",
-        "is-typed-array": "^1.1.10"
+        "gopd": "^1.0.1",
+        "has-proto": "^1.0.3",
+        "is-typed-array": "^1.1.13"
       },
       "engines": {
         "node": ">= 0.4"
@@ -13350,16 +13577,17 @@
       }
     },
     "node_modules/typed-array-byte-offset": {
-      "version": "1.0.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/typed-array-byte-offset/-/typed-array-byte-offset-1.0.0.tgz",
-      "integrity": "sha1-y76JtR/e+c1qrwetRwc0CrvE6gs=",
+      "version": "1.0.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/typed-array-byte-offset/-/typed-array-byte-offset-1.0.2.tgz",
+      "integrity": "sha1-+eway5JZ85UJPkVn6zwopYDQIGM=",
       "license": "MIT",
       "dependencies": {
-        "available-typed-arrays": "^1.0.5",
-        "call-bind": "^1.0.2",
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.7",
         "for-each": "^0.3.3",
-        "has-proto": "^1.0.1",
-        "is-typed-array": "^1.1.10"
+        "gopd": "^1.0.1",
+        "has-proto": "^1.0.3",
+        "is-typed-array": "^1.1.13"
       },
       "engines": {
         "node": ">= 0.4"
@@ -13369,14 +13597,20 @@
       }
     },
     "node_modules/typed-array-length": {
-      "version": "1.0.4",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/typed-array-length/-/typed-array-length-1.0.4.tgz",
-      "integrity": "sha1-idg3heXECYvscuCLMZZR8OrJwbs=",
+      "version": "1.0.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/typed-array-length/-/typed-array-length-1.0.6.tgz",
+      "integrity": "sha1-VxVSB8duZKNFdILf3BydHTxMc6M=",
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
+        "call-bind": "^1.0.7",
         "for-each": "^0.3.3",
-        "is-typed-array": "^1.1.9"
+        "gopd": "^1.0.1",
+        "has-proto": "^1.0.3",
+        "is-typed-array": "^1.1.13",
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -13588,12 +13822,12 @@
       "license": "MIT"
     },
     "node_modules/url/node_modules/qs": {
-      "version": "6.11.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/qs/-/qs-6.11.2.tgz",
-      "integrity": "sha1-ZL6lHxLB9dobwBSW9I/8/3xp19k=",
+      "version": "6.12.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/qs/-/qs-6.12.0.tgz",
+      "integrity": "sha1-7dQMO4I5lZRqigsfIIZpx6IA23c=",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.0.4"
+        "side-channel": "^1.0.6"
       },
       "engines": {
         "node": ">=0.6"
@@ -13652,9 +13886,9 @@
       "license": "MIT"
     },
     "node_modules/v8-to-istanbul": {
-      "version": "9.1.3",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/v8-to-istanbul/-/v8-to-istanbul-9.1.3.tgz",
-      "integrity": "sha1-6kVmBBAc0YAFrCyuPN0aoFimMGs=",
+      "version": "9.2.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/v8-to-istanbul/-/v8-to-istanbul-9.2.0.tgz",
+      "integrity": "sha1-LtdkSiRc3dg9Tgh7mzOz5i39EK0=",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -13792,16 +14026,16 @@
       "license": "ISC"
     },
     "node_modules/which-typed-array": {
-      "version": "1.1.13",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/which-typed-array/-/which-typed-array-1.1.13.tgz",
-      "integrity": "sha1-hwzVvgbdthb1BOewOcTCSJgYTTY=",
+      "version": "1.1.15",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/which-typed-array/-/which-typed-array-1.1.15.tgz",
+      "integrity": "sha1-JkhZ6bEaZJs4i/qvT3Z98fd5s40=",
       "license": "MIT",
       "dependencies": {
-        "available-typed-arrays": "^1.0.5",
-        "call-bind": "^1.0.4",
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.7",
         "for-each": "^0.3.3",
         "gopd": "^1.0.1",
-        "has-tostringtag": "^1.0.0"
+        "has-tostringtag": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -13823,9 +14057,9 @@
       }
     },
     "node_modules/winston": {
-      "version": "3.11.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/winston/-/winston-3.11.0.tgz",
-      "integrity": "sha1-LVCwppWidYuxyVJ58KiOhYFj7ZE=",
+      "version": "3.13.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/winston/-/winston-3.13.0.tgz",
+      "integrity": "sha1-52wNci944Eg4FYxhrcEocgHefOM=",
       "license": "MIT",
       "dependencies": {
         "@colors/colors": "^1.6.0",
@@ -13838,7 +14072,7 @@
         "safe-stable-stringify": "^2.3.1",
         "stack-trace": "0.0.x",
         "triple-beam": "^1.3.0",
-        "winston-transport": "^4.5.0"
+        "winston-transport": "^4.7.0"
       },
       "engines": {
         "node": ">= 12.0.0"
@@ -13872,9 +14106,9 @@
       }
     },
     "node_modules/winston-transport": {
-      "version": "4.6.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/winston-transport/-/winston-transport-4.6.0.tgz",
-      "integrity": "sha1-8cGmZa0bNm33IZnieJJyGDKhnhs=",
+      "version": "4.7.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/winston-transport/-/winston-transport-4.7.0.tgz",
+      "integrity": "sha1-4wLmiJ5sy384O5Jt9pNqW3gb0fA=",
       "license": "MIT",
       "dependencies": {
         "logform": "^2.3.2",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "login.dfe.healthcheck": "git+https://github.com/DFE-Digital/login.dfe.healthcheck.git#v3.0.0",
     "login.dfe.jwt-strategies": "git+https://github.com/DFE-Digital/login.dfe.jwt-strategies.git#v4.0.0",
     "login.dfe.public-api.jobs.client": "git+https://github.com/DFE-Digital/login.dfe.public-api.jobs.client.git#v3.0.0",
-    "login.dfe.request-promise-retry": "git+https://github.com/DFE-Digital/login.dfe.request-promise-retry.git#v3.0.0",
+    "login.dfe.request-promise-retry": "git+https://github.com/DFE-Digital/login.dfe.request-promise-retry.git#v3.1.0",
     "login.dfe.sanitization": "git+https://github.com/DFE-Digital/login.dfe.sanitization.git#v3.0.0",
     "login.dfe.winston-appinsights": "git+https://github.com/DFE-Digital/login.dfe.winston-appinsights.git#v5.0.0",
     "niceware": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "scripts": {
     "dev": "settings='./config/login.dfe.public-api.dev.json' node src/index.js",
-    "test": "settings='./config/login.dfe.public-api.local.json' ./node_modules/.bin/jest --runInBand --detectOpenHandles --forceExit"
+    "test": "jest"
   },
   "engines": {
     "node": "18.x.x"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "scripts": {
     "dev": "settings='./config/login.dfe.public-api.dev.json' node src/index.js",
-    "test": "jest"
+    "test": "jest --coverage"
   },
   "engines": {
     "node": "18.x.x"

--- a/src/app/services/getServiceRoles.js
+++ b/src/app/services/getServiceRoles.js
@@ -27,7 +27,11 @@ const getServiceRoles = async (req, res) => {
 
   const roles = await getRoles(service.id, correlationId) ?? [];
 
-  return res.json(roles);
+  return res.json(roles.map((role) => ({
+    name: role.name,
+    code: role.code,
+    status: (role.status?.id === 1) ? 'Active' : 'Inactive',
+  })));
 };
 
 module.exports = getServiceRoles;

--- a/src/app/services/index.js
+++ b/src/app/services/index.js
@@ -17,11 +17,12 @@ const area = () => {
   const router = express.Router();
 
   router.get('/', asyncWrapper(listServices));
+  router.post('/', asyncWrapper(createService));
   router.get('/:clientid', asyncWrapper(getService));
   router.patch('/:clientid', asyncWrapper(updateService));
   router.delete('/:clientid', asyncWrapper(deleteService));
-  router.post('/', asyncWrapper(createService));
   router.post('/:clientid/regenerate-secret', asyncWrapper(regenerateSecret));
+  router.get('/:clientid/roles', asyncWrapper(getServiceRoles));
 
   router.post('/:sid/invitations', asyncWrapper(inviteUser));
   router.get('/:sid/organisations/:oid/users/:uid', asyncWrapper(getUsersAccess));
@@ -29,7 +30,6 @@ const area = () => {
 
   router.get('/:sid/grants', asyncWrapper(serviceGrants));
   router.get('/:sid/grants/:grantId/tokens', asyncWrapper(serviceGrantTokens));
-  router.get('/:clientId/roles', asyncWrapper(getServiceRoles));
 
   return router;
 };

--- a/src/infrastructure/applications/api.js
+++ b/src/infrastructure/applications/api.js
@@ -1,7 +1,7 @@
-const config = require('./../config');
-
 const rp = require('login.dfe.request-promise-retry');
 const jwtStrategy = require('login.dfe.jwt-strategies');
+
+const config = require('../config');
 
 const getClientByServiceId = async (id) => {
   if (!id) {
@@ -154,27 +154,6 @@ const listServiceGrantTokens = async (serviceId, grantId, page, pageSize, correl
   }
 };
 
-const getAllRolesForService = async (clientId, correlationId) => {
-  const token = await jwtStrategy(config.applications.service).getBearerToken();
-  try {
-    const rolesForService = await rp({
-      method: 'GET',
-      uri: `${config.applications.service.url}/services/${clientId}/roles`,
-      headers: {
-        authorization: `bearer ${token}`,
-        'x-correlation-id': correlationId,
-      },
-      json: true,
-    });
-    return rolesForService;
-  } catch (e) {
-    if (e.statusCode === 404) {
-      return undefined;
-    }
-    throw e;
-  }
-};
-
 module.exports = {
   getClientByServiceId,
   createService,
@@ -183,5 +162,4 @@ module.exports = {
   destroyService,
   listServiceGrants,
   listServiceGrantTokens,
-  getAllRolesForService,
 };

--- a/src/infrastructure/applications/api.js
+++ b/src/infrastructure/applications/api.js
@@ -3,7 +3,7 @@ const jwtStrategy = require('login.dfe.jwt-strategies');
 
 const config = require('../config');
 
-const getClientByServiceId = async (id) => {
+const getClientByServiceId = async (id, correlationId) => {
   if (!id) {
     return undefined;
   }
@@ -14,6 +14,7 @@ const getClientByServiceId = async (id) => {
       uri: `${config.applications.service.url}/services/${id}`,
       headers: {
         authorization: `bearer ${token}`,
+        'x-correlation-id': correlationId,
       },
       json: true,
     });

--- a/src/infrastructure/applications/static.js
+++ b/src/infrastructure/applications/static.js
@@ -35,16 +35,9 @@ const listServices = async (parentId, page, pageSize, correlationId) => {
   });
 };
 
-const getServiceRoles = async (clientId) => {
-  return Promise.resolve({
-    roles: []
-  });
-};
-
 module.exports = {
   getClientByServiceId,
   createService,
   updateService,
   listServices,
-  getServiceRoles,
 };

--- a/test/app/services/getServiceRoles.test.js
+++ b/test/app/services/getServiceRoles.test.js
@@ -12,24 +12,6 @@ const { getClientByServiceId } = require('../../../src/infrastructure/applicatio
 const { getRoles } = require('../../../src/infrastructure/access');
 const getServiceRoles = require('../../../src/app/services/getServiceRoles');
 
-const getRolesResult = [{
-  id: 'role-1',
-  name: 'Role One',
-  code: 'Role1',
-  numericId: '123456',
-  status: {
-    id: 1,
-  },
-}, {
-  id: 'role-2',
-  name: 'Role Two',
-  code: 'Role2',
-  numericId: '678910',
-  status: {
-    id: 1,
-  },
-}];
-
 describe('When getting the roles for a service', () => {
   let req;
 
@@ -57,7 +39,23 @@ describe('When getting the roles for a service', () => {
       },
     });
 
-    getRoles.mockReset().mockReturnValue(getRolesResult);
+    getRoles.mockReset().mockReturnValue([{
+      id: 'role-1',
+      name: 'Role One',
+      code: 'Role1',
+      numericId: '123456',
+      status: {
+        id: 1,
+      },
+    }, {
+      id: 'role-2',
+      name: 'Role Two',
+      code: 'Role2',
+      numericId: '678910',
+      status: {
+        id: 0,
+      },
+    }]);
   });
 
   it('then it should log the request', async () => {
@@ -98,7 +96,7 @@ describe('When getting the roles for a service', () => {
     await getServiceRoles(req, res);
 
     expect(res.json).toHaveBeenCalledTimes(1);
-    expect(res.json).toHaveBeenCalledWith(getRolesResult);
+    expect(res.json.mock.calls[0][0].length).toEqual(getRoles().length);
   });
 
   it('then it should return the roles if the requester is the requested service', async () => {
@@ -106,7 +104,7 @@ describe('When getting the roles for a service', () => {
     await getServiceRoles(req, res);
 
     expect(res.json).toHaveBeenCalledTimes(1);
-    expect(res.json).toHaveBeenCalledWith(getRolesResult);
+    expect(res.json.mock.calls[0][0].length).toEqual(getRoles().length);
   });
 
   it('then it should return an empty array if the requested service has no roles', async () => {
@@ -116,5 +114,87 @@ describe('When getting the roles for a service', () => {
 
     expect(res.json).toHaveBeenCalledTimes(1);
     expect(res.json).toHaveBeenCalledWith([]);
+  });
+
+  it('then it should return only the name, code, and status properties as strings', async () => {
+    await getServiceRoles(req, res);
+
+    expect(res.json).toHaveBeenCalledTimes(1);
+    res.json.mock.calls[0][0].forEach((role) => {
+      // Check for only those properties.
+      expect(Object.keys(role).sort()).toEqual(['code', 'name', 'status']);
+      // Check the property values are strings.
+      expect(role).toEqual(expect.objectContaining({
+        name: expect.any(String),
+        code: expect.any(String),
+        status: expect.any(String),
+      }));
+    });
+  });
+
+  it('then it should return the correct name and code values', async () => {
+    const getRolesValues = [{
+      name: 'Role One',
+      code: 'Role1',
+    }, {
+      name: 'Role Two',
+      code: 'Role2',
+    }];
+    getRoles.mockReturnValue(getRolesValues);
+
+    await getServiceRoles(req, res);
+
+    expect(res.json).toHaveBeenCalledTimes(1);
+    res.json.mock.calls[0][0].forEach((role, index) => {
+      expect(role).toEqual(expect.objectContaining({
+        name: getRolesValues[index].name,
+        code: getRolesValues[index].code,
+      }));
+    });
+  });
+
+  it('then it should return the status as "Active" if the status ID is 1', async () => {
+    getRoles.mockReset().mockReturnValue([{
+      id: 'role-1',
+      name: 'Role One',
+      code: 'Role1',
+      numericId: '123456',
+      status: {
+        id: 1,
+      },
+    }]);
+    await getServiceRoles(req, res);
+
+    expect(res.json).toHaveBeenCalledTimes(1);
+    expect(res.json.mock.calls[0][0][0].status).toEqual('Active');
+  });
+
+  it('then it should return the status as "Inactive" if the status ID is 0', async () => {
+    getRoles.mockReturnValue([{
+      id: 'role-1',
+      name: 'Role One',
+      code: 'Role1',
+      numericId: '123456',
+      status: {
+        id: 0,
+      },
+    }]);
+    await getServiceRoles(req, res);
+
+    expect(res.json).toHaveBeenCalledTimes(1);
+    expect(res.json.mock.calls[0][0][0].status).toEqual('Inactive');
+  });
+
+  it('then it should return the status as "Inactive" if the status property does not exist', async () => {
+    getRoles.mockReturnValue([{
+      id: 'role-1',
+      name: 'Role One',
+      code: 'Role1',
+      numericId: '123456',
+    }]);
+    await getServiceRoles(req, res);
+
+    expect(res.json).toHaveBeenCalledTimes(1);
+    expect(res.json.mock.calls[0][0][0].status).toEqual('Inactive');
   });
 });

--- a/test/app/services/getServiceRoles.test.js
+++ b/test/app/services/getServiceRoles.test.js
@@ -1,51 +1,78 @@
-jest.mock('./../../../src/infrastructure/config', () => require('../../utils').mockConfig());
-jest.mock('./../../../src/infrastructure/applications');
+const mockUtils = require('../../utils');
 
-const { mockResponse, mockRequest } = require('../../utils');
+const res = mockUtils.mockResponse();
+const mockLogger = mockUtils.mockLogger();
+
+jest.mock('../../../src/infrastructure/config', () => mockUtils.mockConfig());
+jest.mock('../../../src/infrastructure/logger', () => mockLogger);
+jest.mock('../../../src/infrastructure/applications');
+jest.mock('../../../src/infrastructure/access');
+
 const { getClientByServiceId } = require('../../../src/infrastructure/applications');
-const getService = require('../../../src/app/services/getService');
+const { getRoles } = require('../../../src/infrastructure/access');
+const getServiceRoles = require('../../../src/app/services/getServiceRoles');
 
-const res = mockResponse();
+const getRolesResult = [{
+  id: 'role-1',
+  name: 'Role One',
+  code: 'Role1',
+  numericId: '123456',
+  status: {
+    id: 1,
+  },
+}, {
+  id: 'role-2',
+  name: 'Role Two',
+  code: 'Role2',
+  numericId: '678910',
+  status: {
+    id: 1,
+  },
+}];
 
-describe('when getting specific service', () => {
+describe('When getting the roles for a service', () => {
   let req;
 
   beforeEach(() => {
-    req = mockRequest({
+    req = mockUtils.mockRequest({
       client: {
         id: 'parent-1',
         relyingParty: {
-          params: {
-            canCreateChildApplications: 'true',
-          },
+          client_id: 'req-clientId',
         },
       },
-    });
-    res.mockResetAll();
-
-    getAllRolesForService.mockReset().mockReturnValue({
-      id: 'service-1',
-      name: 'Service One',
-      description: 'First service',
-      parentId: 'parent-1',
-      relyingParty: {
-        client_id: 'csvc1',
-        client_secret: 'some-super-secure-secret',
-        redirect_uris: ['https://localhost:1234/auth/cb'],
+      params: {
+        clientid: 'svc-clientId',
       },
     });
+
+    res.mockResetAll();
+    mockLogger.mockResetAll();
+
+    getClientByServiceId.mockReset().mockReturnValue({
+      id: 'service-1',
+      parentId: 'parent-1',
+      relyingParty: {
+        client_id: 'svc-clientId',
+      },
+    });
+
+    getRoles.mockReset().mockReturnValue(getRolesResult);
   });
 
-  it('then it should return service role list', async () => {
+  it('then it should log the request', async () => {
     await getServiceRoles(req, res);
 
-    expect(res.send).toHaveBeenCalledTimes(1);
-    expect(res.send).toHaveBeenCalledWith({
-      clientId: 'csvc1'
+    expect(mockLogger.info).toHaveBeenCalledTimes(1);
+    expect(mockLogger.info).toHaveBeenCalledWith(`req-clientId is attempting to get service roles for: svc-clientId (correlationId: ${req.correlationId}, clientCorrelationId: ${req.clientCorrelationId})`, {
+      correlationId: req.correlationId,
+      clientCorrelationId: req.clientCorrelationId,
+      requester: 'req-clientId',
+      requestedClientId: 'svc-clientId',
     });
   });
 
-  it('then it should return not found if client does not exist', async () => {
+  it('then it should return 404 if the requested service does not exist', async () => {
     getClientByServiceId.mockReturnValue(undefined);
 
     await getServiceRoles(req, res);
@@ -55,13 +82,39 @@ describe('when getting specific service', () => {
     expect(res.send).toHaveBeenCalledTimes(1);
   });
 
-  it('then it should return not authorized if client not child of caller', async () => {
-    req.client.id = 'not-the-parent';
+  it('then it should return 403 if the requester is neither the parent of, or the requested service itself', async () => {
+    req.client.id = 'not-a-match';
+    req.client.relyingParty.client_id = 'not-a-match';
 
     await getServiceRoles(req, res);
 
     expect(res.status).toHaveBeenCalledTimes(1);
     expect(res.status).toHaveBeenCalledWith(403);
     expect(res.send).toHaveBeenCalledTimes(1);
+  });
+
+  it('then it should return the roles if the requester is the parent of the requested service', async () => {
+    req.client.relyingParty.client_id = 'req-clientId';
+    await getServiceRoles(req, res);
+
+    expect(res.json).toHaveBeenCalledTimes(1);
+    expect(res.json).toHaveBeenCalledWith(getRolesResult);
+  });
+
+  it('then it should return the roles if the requester is the requested service', async () => {
+    req.client.relyingParty.client_id = 'svc-clientId';
+    await getServiceRoles(req, res);
+
+    expect(res.json).toHaveBeenCalledTimes(1);
+    expect(res.json).toHaveBeenCalledWith(getRolesResult);
+  });
+
+  it('then it should return an empty array if the requested service has no roles', async () => {
+    getRoles.mockReturnValue(undefined);
+
+    await getServiceRoles(req, res);
+
+    expect(res.json).toHaveBeenCalledTimes(1);
+    expect(res.json).toHaveBeenCalledWith([]);
   });
 });

--- a/test/app/services/getUsersAccess.test.js
+++ b/test/app/services/getUsersAccess.test.js
@@ -1,12 +1,21 @@
-jest.mock('./../../../src/infrastructure/config', () => require('./../../utils').mockConfig());
-jest.mock('./../../../src/infrastructure/logger', () => require('./../../utils').mockLogger());
+const { organisation } = require('login.dfe.dao');
+const {
+  mockRequest, mockResponse, mockConfig, mockLogger,
+} = require('../../utils');
+const { getUsersAccessToServiceAtOrganisation } = require('../../../src/infrastructure/access');
+const getUsersAccess = require('../../../src/app/services/getUsersAccess');
+const { getClientByServiceId } = require('../../../src/infrastructure/applications');
+
+jest.mock('./../../../src/infrastructure/config', () => mockConfig());
+jest.mock('./../../../src/infrastructure/logger', () => mockLogger());
+jest.mock('login.dfe.dao', () => ({
+  organisation: {
+    getOrganisation: jest.fn(),
+    getUserOrganisationIdentifiers: jest.fn(),
+  },
+}));
 jest.mock('./../../../src/infrastructure/access');
 jest.mock('./../../../src/infrastructure/applications');
-
-const { mockRequest, mockResponse } = require('./../../utils');
-const { getUsersAccessToServiceAtOrganisation } = require('./../../../src/infrastructure/access');
-const getUsersAccess = require('./../../../src/app/services/getUsersAccess');
-const { getClientByServiceId } = require('./../../../src/infrastructure/applications');
 
 const uid = 'b5d58c18-a13c-4ecc-a7cd-0003350447e1';
 const sid = 'e191b83e-233c-4142-9d4c-df0454fed8ab';
@@ -45,7 +54,17 @@ describe('when getting users access to service', () => {
       organisationId: oid,
       roles: ['role1', 'role1'],
       identifiers: [{ key: 'some', value: 'thing' }],
-      accessGrantedOn: '2018-08-17T15:44:16Z'
+      accessGrantedOn: '2018-08-17T15:44:16Z',
+    });
+
+    organisation.getUserOrganisationIdentifiers.mockReset().mockReturnValue({
+      numericIdentifier: 123456,
+      textIdentifier: 'foobarbaz',
+    });
+
+    organisation.getOrganisation.mockReset().mockReturnValue({
+      legacyId: '123456',
+      IsOnAPAR: true,
     });
   });
 


### PR DESCRIPTION
Ticket: https://dfe-secureaccess.atlassian.net/browse/NSA-7636

This PR fixes the issues with the "Get Service Roles" endpoint (which had only got to Dev/Test but had issues). With/as well as the following changes:

- ESLint fixes to stop false-positives on new syntax and node/jest code.
- Updates for the description of this endpoint in the Postman collections.
- Updates to the README for this endpoint to show the possible response code and the correct return examples.
- Updated `login.dfe.request-promise-retry` to v3.1.0 to stop request bodies from being logged to the app console.
- A rewrite of the new get service roles endpoint (`src/app/services/getServiceRoles.js`) as well as its unit tests (`test/app/services/getServiceRoles.test.js`) to ensure it returns the correct status code and information.
- Removal of `getAllRolesForService` in the Applications API routes, as this doesn't exist, it's Access that handles that.
- Updates mocking of unit tests to not require a connection to any external resource, and now the pipeline unit tests have been enabled 👍 