### PR TITLE
Bump app version in package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "login.dfe.public-api",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "login.dfe.public-api",
-      "version": "2.0.0",
+      "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
         "agentkeepalive": "^4.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "login.dfe.public-api",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "",
   "scripts": {
     "dev": "settings='./config/login.dfe.public-api.dev.json' node src/index.js",


### PR DESCRIPTION
Current latest release is version 3.0.0 (as of the time of making this PR).  We think the pipeline is bumping version 2.0.0 to version 3.0.0, then trying to make a release and a tag with it.  3.0.0 already exists, and it's silently failing.