### PR TITLE
[DSI-7552] Upgrade to Node version 22

### DIFF
--- a/DevOps/pipeline/azure-pipeline.yml
+++ b/DevOps/pipeline/azure-pipeline.yml
@@ -112,7 +112,7 @@ stages:
                 - ${{ if eq(variables.pr, 'true') }}:
                     - pr
               pm2ProcessFileName: process.json
-              nodeVersionSpec: "18.17.0"
+              nodeVersionSpec: "22.11.0"
               useRevisedLinting: true
 
   - ${{ each location in parameters.location }}:
@@ -156,7 +156,7 @@ stages:
                       releaseArtifactName: ${{variables.applicationShortName}}-${{env}}-$(Build.BuildId)-release
                       InfrDeploy: ${{parameters.InfrDeploy}}
                       deploymentLocation: ${{location}}
-                      runtimeStack: NODE|18-lts
+                      runtimeStack: NODE|22-lts
                       pm2ProcessFileName: process.json
                       gitCheck: ${{parameters.gitCheck}}
 

--- a/DevOps/templates/template.json
+++ b/DevOps/templates/template.json
@@ -38,7 +38,7 @@
     },
     "nodeVersion": {
       "type": "string",
-      "defaultValue": "NODE|14-lts",
+      "defaultValue": "NODE|22-lts",
       "metadata": {
         "description": "The default NodeJS version that the App Service will run"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,30 +9,30 @@
       "version": "8.0.0",
       "license": "MIT",
       "dependencies": {
-        "agentkeepalive": "^4.5.0",
+        "agentkeepalive": "^4.6.0",
         "applicationinsights": "^2.9.1",
-        "body-parser": "^1.18.3",
+        "body-parser": "^1.20.3",
         "email-validator": "^2.0.4",
-        "express": "^4.16.3",
-        "express-validator": "^7.0.1",
+        "express": "^4.21.2",
+        "express-validator": "^7.2.1",
         "helmet": "^7.1.0",
         "jsonwebtoken": "^9.0.2",
-        "lodash": "^4.17.15",
+        "lodash": "^4.17.21",
         "login.dfe.api.auth": "github:DFE-Digital/login.dfe.api.auth#v2.3.3",
         "login.dfe.async-retry": "github:DFE-Digital/login.dfe.async-retry#v2.0.3",
-        "login.dfe.audit.transporter": "^4.0.1",
+        "login.dfe.audit.transporter": "^4.0.2",
         "login.dfe.audit.winston-sequelize-transport": "github:DFE-Digital/login.dfe.audit.winston-sequelize-transport#v3.2.4",
         "login.dfe.dao": "^5.0.3",
-        "login.dfe.express-error-handling": "github:DFE-Digital/login.dfe.express-error-handling#v3.0.1",
+        "login.dfe.express-error-handling": "github:DFE-Digital/login.dfe.express-error-handling#v3.0.2",
         "login.dfe.healthcheck": "github:DFE-Digital/login.dfe.healthcheck#v3.0.2",
         "login.dfe.jobs-client": "github:DFE-Digital/login.dfe.jobs-client#v6.1.0",
         "login.dfe.jwt-strategies": "github:DFE-Digital/login.dfe.jwt-strategies#v4.1.1",
-        "login.dfe.sanitization": "github:DFE-Digital/login.dfe.sanitization#v3.0.1",
+        "login.dfe.sanitization": "^3.0.4",
         "login.dfe.winston-appinsights": "github:DFE-Digital/login.dfe.winston-appinsights#v5.0.3",
         "niceware": "^4.0.0",
-        "uuid": "^9.0.1",
+        "uuid": "^10.0.0",
         "valid-url": "^1.0.9",
-        "winston": "^3.11.0"
+        "winston": "^3.15.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.17.0",
@@ -49,9 +49,6 @@
         "nodemon": "^3.0.1",
         "prettier": "^3.4.2",
         "supertest": "^6.2.4"
-      },
-      "engines": {
-        "node": "18.x.x"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -2748,9 +2745,9 @@
       "license": "MIT"
     },
     "node_modules/agentkeepalive": {
-      "version": "4.5.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/agentkeepalive/-/agentkeepalive-4.5.0.tgz",
-      "integrity": "sha1-JnOtE4mzxBjFogxdc2T5PKBL6SM=",
+      "version": "4.6.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
+      "integrity": "sha1-Nfc+lLP0C/ZfEFIZxiOtGcE26mo=",
       "license": "MIT",
       "dependencies": {
         "humanize-ms": "^1.2.1"
@@ -3147,6 +3144,7 @@
       "version": "1.20.3",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/body-parser/-/body-parser-1.20.3.tgz",
       "integrity": "sha1-GVNDEiHG+1zWPEs21T+rCSjlSMY=",
+      "license": "MIT",
       "dependencies": {
         "bytes": "3.1.2",
         "content-type": "~1.0.5",
@@ -3281,6 +3279,19 @@
         "semver": "^7.5.4",
         "tslib": "^2.0.0",
         "uuid": "^9.0.0"
+      }
+    },
+    "node_modules/bullmq/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha1-4YjUyIU8xyIiA5LEJM1jfzIpPzA=",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/bunyan": {
@@ -4601,9 +4612,9 @@
       }
     },
     "node_modules/express-validator": {
-      "version": "7.1.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/express-validator/-/express-validator-7.1.0.tgz",
-      "integrity": "sha1-5lcfakUgVg4fP64s6rb1bI8mwns=",
+      "version": "7.2.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/express-validator/-/express-validator-7.2.1.tgz",
+      "integrity": "sha1-hAPer4EPm+3toKT9cRaAPkbxIsI=",
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.21",
@@ -5139,12 +5150,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha1-39YAJ9o2o238viNiYsAKWCJoFFM=",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/htmlencode": {
-      "version": "0.0.4",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/htmlencode/-/htmlencode-0.0.4.tgz",
-      "integrity": "sha1-9+LWr74YqHp45jujMI51N2Z0Dj8=",
       "license": "MIT"
     },
     "node_modules/http-errors": {
@@ -7177,6 +7182,19 @@
         "winston-transport": "^4.5.0"
       }
     },
+    "node_modules/login.dfe.audit.winston-sequelize-transport/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha1-4YjUyIU8xyIiA5LEJM1jfzIpPzA=",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/login.dfe.config.schema.common": {
       "version": "1.9.4",
       "resolved": "git+ssh://git@github.com/DFE-Digital/login.dfe.config.schema.common.git#56d274b1a915c28faa06621e1ab1e26e953bb62b",
@@ -7189,6 +7207,7 @@
       "version": "5.0.3",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/login.dfe.dao/-/login.dfe.dao-5.0.3.tgz",
       "integrity": "sha1-5ff2NtLhRFeXESo7sF/2jGqGw3M=",
+      "license": "ISC",
       "dependencies": {
         "eslint": "^8.12.0",
         "express": "^4.17.3",
@@ -7388,17 +7407,30 @@
       "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI=",
       "license": "MIT"
     },
+    "node_modules/login.dfe.dao/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha1-4YjUyIU8xyIiA5LEJM1jfzIpPzA=",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/login.dfe.express-error-handling": {
-      "version": "3.0.1",
-      "resolved": "git+ssh://git@github.com/DFE-Digital/login.dfe.express-error-handling.git#2b1de1f9e1cc8d14afff441ff97c344d9c6cbc86",
+      "version": "3.0.2",
+      "resolved": "git+ssh://git@github.com/DFE-Digital/login.dfe.express-error-handling.git#405082e18f5e9eff0d2b4279626d6e5e3abb52a6",
       "license": "MIT",
       "dependencies": {
         "ejs": "^3.1.6"
       }
     },
     "node_modules/login.dfe.healthcheck": {
-      "version": "3.0.1",
-      "resolved": "git+ssh://git@github.com/DFE-Digital/login.dfe.healthcheck.git#d21c9528e344437264ac360c13041fda6131bcca",
+      "version": "3.0.2",
+      "resolved": "git+ssh://git@github.com/DFE-Digital/login.dfe.healthcheck.git#c4f925a38c78992195a22fae93dfe3ad8fbe5a66",
       "license": "MIT",
       "dependencies": {
         "express": "^4.17.3",
@@ -7424,11 +7456,11 @@
       }
     },
     "node_modules/login.dfe.sanitization": {
-      "version": "3.0.1",
-      "resolved": "git+ssh://git@github.com/DFE-Digital/login.dfe.sanitization.git#dd9afb2e58e2b2b1a39e1f71884f808099854445",
+      "version": "3.0.4",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/login.dfe.sanitization/-/login.dfe.sanitization-3.0.4.tgz",
+      "integrity": "sha1-ySPS+oNOmm0LOmnQ8yRV62ts9rQ=",
       "license": "MIT",
       "dependencies": {
-        "htmlencode": "0.0.4",
         "sanitizer": "^0.1.3"
       }
     },
@@ -7856,6 +7888,19 @@
         "pako": "^2.0.4",
         "process": "^0.11.10",
         "uuid": "^9.0.0"
+      }
+    },
+    "node_modules/node-jose/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha1-4YjUyIU8xyIiA5LEJM1jfzIpPzA=",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/node-mocks-http": {
@@ -10027,9 +10072,9 @@
       }
     },
     "node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha1-4YjUyIU8xyIiA5LEJM1jfzIpPzA=",
+      "version": "10.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha1-WpWqRU5uACclx5BV/UKqujDKYpQ=",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -10117,16 +10162,16 @@
       }
     },
     "node_modules/winston": {
-      "version": "3.13.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/winston/-/winston-3.13.0.tgz",
-      "integrity": "sha1-52wNci944Eg4FYxhrcEocgHefOM=",
+      "version": "3.15.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/winston/-/winston-3.15.0.tgz",
+      "integrity": "sha1-Tfe3C+CRvBo4pPRblp+nlYm3P/U=",
       "license": "MIT",
       "dependencies": {
         "@colors/colors": "^1.6.0",
         "@dabh/diagnostics": "^2.0.2",
         "async": "^3.2.3",
         "is-stream": "^2.0.0",
-        "logform": "^2.4.0",
+        "logform": "^2.6.0",
         "one-time": "^1.0.0",
         "readable-stream": "^3.4.0",
         "safe-stable-stringify": "^2.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
         "login.dfe.api.auth": "github:DFE-Digital/login.dfe.api.auth#v2.3.3",
         "login.dfe.async-retry": "github:DFE-Digital/login.dfe.async-retry#v2.0.3",
         "login.dfe.audit.transporter": "^4.0.2",
-        "login.dfe.audit.winston-sequelize-transport": "github:DFE-Digital/login.dfe.audit.winston-sequelize-transport#v3.2.4",
         "login.dfe.dao": "^5.0.3",
         "login.dfe.express-error-handling": "github:DFE-Digital/login.dfe.express-error-handling#v3.0.2",
         "login.dfe.healthcheck": "github:DFE-Digital/login.dfe.healthcheck#v3.0.2",
@@ -78,9 +77,9 @@
       }
     },
     "node_modules/@azure/core-amqp": {
-      "version": "4.3.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/core-amqp/-/core-amqp-4.3.0.tgz",
-      "integrity": "sha1-SqGWrJs1HpgUIGd+eysJJaQFtsU=",
+      "version": "4.3.5",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/core-amqp/-/core-amqp-4.3.5.tgz",
+      "integrity": "sha1-6KpIRBsB3XCTVTB6Q4kOLMtAnWY=",
       "license": "MIT",
       "dependencies": {
         "@azure/abort-controller": "^2.0.0",
@@ -92,19 +91,6 @@
         "process": "^0.11.10",
         "rhea": "^3.0.0",
         "rhea-promise": "^3.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@azure/core-amqp/node_modules/@azure/core-util": {
-      "version": "1.9.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/core-util/-/core-util-1.9.0.tgz",
-      "integrity": "sha1-Rpr9fmRS1TiLGJ+Q0z93VrCyENE=",
-      "license": "MIT",
-      "dependencies": {
-        "@azure/abort-controller": "^2.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -143,28 +129,48 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@azure/core-client/node_modules/@azure/core-util": {
-      "version": "1.9.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/core-util/-/core-util-1.9.0.tgz",
-      "integrity": "sha1-Rpr9fmRS1TiLGJ+Q0z93VrCyENE=",
+    "node_modules/@azure/core-http-compat": {
+      "version": "2.2.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/core-http-compat/-/core-http-compat-2.2.0.tgz",
+      "integrity": "sha1-IP9TWyRgFR6n5odnKHmWyEzShzg=",
       "license": "MIT",
       "dependencies": {
         "@azure/abort-controller": "^2.0.0",
+        "@azure/core-client": "^1.3.0",
+        "@azure/core-rest-pipeline": "^1.19.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/core-http-compat/node_modules/@azure/core-auth": {
+      "version": "1.9.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/core-auth/-/core-auth-1.9.0.tgz",
+      "integrity": "sha1-rHJbA/q+PIkjcQZe6eIEG+4P0aw=",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.0.0",
+        "@azure/core-util": "^1.11.0",
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@azure/core-http-compat": {
-      "version": "2.1.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/core-http-compat/-/core-http-compat-2.1.2.tgz",
-      "integrity": "sha1-0Vha2iS6dQ3BYdgWFpszs192Lw0=",
+    "node_modules/@azure/core-http-compat/node_modules/@azure/core-rest-pipeline": {
+      "version": "1.19.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/core-rest-pipeline/-/core-rest-pipeline-1.19.0.tgz",
+      "integrity": "sha1-TMYNPy7mjPDvN5hRtO0XX3kyyMU=",
       "license": "MIT",
       "dependencies": {
         "@azure/abort-controller": "^2.0.0",
-        "@azure/core-client": "^1.3.0",
-        "@azure/core-rest-pipeline": "^1.3.0"
+        "@azure/core-auth": "^1.8.0",
+        "@azure/core-tracing": "^1.0.1",
+        "@azure/core-util": "^1.11.0",
+        "@azure/logger": "^1.0.0",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -198,51 +204,28 @@
       }
     },
     "node_modules/@azure/core-rest-pipeline": {
-      "version": "1.10.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/core-rest-pipeline/-/core-rest-pipeline-1.10.1.tgz",
-      "integrity": "sha1-NIKQhHyjG57s+c9d51GarM3TCWg=",
+      "version": "1.16.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/core-rest-pipeline/-/core-rest-pipeline-1.16.3.tgz",
+      "integrity": "sha1-veO8PrrX+IXd2d5q9eWo/CVLKH4=",
       "license": "MIT",
       "dependencies": {
-        "@azure/abort-controller": "^1.0.0",
+        "@azure/abort-controller": "^2.0.0",
         "@azure/core-auth": "^1.4.0",
         "@azure/core-tracing": "^1.0.1",
-        "@azure/core-util": "^1.0.0",
+        "@azure/core-util": "^1.9.0",
         "@azure/logger": "^1.0.0",
-        "form-data": "^4.0.0",
-        "http-proxy-agent": "^5.0.0",
-        "https-proxy-agent": "^5.0.0",
-        "tslib": "^2.2.0",
-        "uuid": "^8.3.0"
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@azure/core-rest-pipeline/node_modules/@azure/abort-controller": {
-      "version": "1.1.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/abort-controller/-/abort-controller-1.1.0.tgz",
-      "integrity": "sha1-eI7nhFelWvihrTQqyxgjg9IRkkk=",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/@azure/core-rest-pipeline/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha1-gNW1ztJxu5r2xEXyGhoExgbO++I=",
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@azure/core-tracing": {
-      "version": "1.1.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/core-tracing/-/core-tracing-1.1.2.tgz",
-      "integrity": "sha1-Bl2rTgk/thiZmIoc28gn2a2QtO4=",
+      "version": "1.2.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/core-tracing/-/core-tracing-1.2.0.tgz",
+      "integrity": "sha1-e+XVPDUi1jnPGQQsvNsZ9xvDWrI=",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -252,84 +235,9 @@
       }
     },
     "node_modules/@azure/core-util": {
-      "version": "1.2.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/core-util/-/core-util-1.2.0.tgz",
-      "integrity": "sha1-NJneuh/DbdpvGRK3kYCbbxXUo5I=",
-      "license": "MIT",
-      "dependencies": {
-        "@azure/abort-controller": "^1.0.0",
-        "tslib": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@azure/core-util/node_modules/@azure/abort-controller": {
-      "version": "1.1.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/abort-controller/-/abort-controller-1.1.0.tgz",
-      "integrity": "sha1-eI7nhFelWvihrTQqyxgjg9IRkkk=",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/@azure/core-xml": {
-      "version": "1.4.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/core-xml/-/core-xml-1.4.2.tgz",
-      "integrity": "sha1-nOZelSDrr8ewwfcRVZYoK/x7MvM=",
-      "license": "MIT",
-      "dependencies": {
-        "fast-xml-parser": "^4.3.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@azure/identity": {
-      "version": "4.3.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/identity/-/identity-4.3.0.tgz",
-      "integrity": "sha1-6NprO/HfTeFRHoE6cWaktbSpnKE=",
-      "license": "MIT",
-      "dependencies": {
-        "@azure/abort-controller": "^1.0.0",
-        "@azure/core-auth": "^1.5.0",
-        "@azure/core-client": "^1.9.2",
-        "@azure/core-rest-pipeline": "^1.1.0",
-        "@azure/core-tracing": "^1.0.0",
-        "@azure/core-util": "^1.3.0",
-        "@azure/logger": "^1.0.0",
-        "@azure/msal-browser": "^3.11.1",
-        "@azure/msal-node": "^2.9.2",
-        "events": "^3.0.0",
-        "jws": "^4.0.0",
-        "open": "^8.0.0",
-        "stoppable": "^1.1.0",
-        "tslib": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@azure/identity/node_modules/@azure/abort-controller": {
-      "version": "1.1.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/abort-controller/-/abort-controller-1.1.0.tgz",
-      "integrity": "sha1-eI7nhFelWvihrTQqyxgjg9IRkkk=",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/@azure/identity/node_modules/@azure/core-util": {
-      "version": "1.9.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/core-util/-/core-util-1.9.0.tgz",
-      "integrity": "sha1-Rpr9fmRS1TiLGJ+Q0z93VrCyENE=",
+      "version": "1.11.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/core-util/-/core-util-1.11.0.tgz",
+      "integrity": "sha1-9TD8Z+c4rqhy+90cyEFucCGfrac=",
       "license": "MIT",
       "dependencies": {
         "@azure/abort-controller": "^2.0.0",
@@ -339,16 +247,98 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@azure/identity/node_modules/@azure/core-util/node_modules/@azure/abort-controller": {
-      "version": "2.1.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
-      "integrity": "sha1-Qv4MyrI4QdmQWBLFjxCC0neEVm0=",
+    "node_modules/@azure/core-xml": {
+      "version": "1.4.4",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/core-xml/-/core-xml-1.4.4.tgz",
+      "integrity": "sha1-qGVnUZQ79JJ2L3WNFH0z382TPZ4=",
       "license": "MIT",
       "dependencies": {
+        "fast-xml-parser": "^4.4.1",
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/identity": {
+      "version": "4.7.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/identity/-/identity-4.7.0.tgz",
+      "integrity": "sha1-s7xXrsQEMomRCP1BF36BaOe7YiM=",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.0.0",
+        "@azure/core-auth": "^1.9.0",
+        "@azure/core-client": "^1.9.2",
+        "@azure/core-rest-pipeline": "^1.17.0",
+        "@azure/core-tracing": "^1.0.0",
+        "@azure/core-util": "^1.11.0",
+        "@azure/logger": "^1.0.0",
+        "@azure/msal-browser": "^4.2.0",
+        "@azure/msal-node": "^3.2.1",
+        "events": "^3.0.0",
+        "jws": "^4.0.0",
+        "open": "^10.1.0",
+        "stoppable": "^1.1.0",
+        "tslib": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/identity/node_modules/@azure/core-auth": {
+      "version": "1.9.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/core-auth/-/core-auth-1.9.0.tgz",
+      "integrity": "sha1-rHJbA/q+PIkjcQZe6eIEG+4P0aw=",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.0.0",
+        "@azure/core-util": "^1.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/identity/node_modules/@azure/core-rest-pipeline": {
+      "version": "1.19.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/core-rest-pipeline/-/core-rest-pipeline-1.19.0.tgz",
+      "integrity": "sha1-TMYNPy7mjPDvN5hRtO0XX3kyyMU=",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.0.0",
+        "@azure/core-auth": "^1.8.0",
+        "@azure/core-tracing": "^1.0.1",
+        "@azure/core-util": "^1.11.0",
+        "@azure/logger": "^1.0.0",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/identity/node_modules/@azure/msal-common": {
+      "version": "15.2.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/msal-common/-/msal-common-15.2.0.tgz",
+      "integrity": "sha1-9OOLqFwKMiCLcEbgEcIf9ie2dVw=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@azure/identity/node_modules/@azure/msal-node": {
+      "version": "3.2.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/msal-node/-/msal-node-3.2.3.tgz",
+      "integrity": "sha1-x0LWbTqRg8HfpBYGMtiJHGmve8w=",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/msal-common": "15.2.0",
+        "jsonwebtoken": "^9.0.0",
+        "uuid": "^8.3.0"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/@azure/identity/node_modules/jwa": {
@@ -372,13 +362,41 @@
         "safe-buffer": "^5.0.1"
       }
     },
-    "node_modules/@azure/keyvault-keys": {
-      "version": "4.8.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/keyvault-keys/-/keyvault-keys-4.8.0.tgz",
-      "integrity": "sha1-FROzoYe7Opo3K1mAxZOWL7eTsq0=",
+    "node_modules/@azure/identity/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha1-gNW1ztJxu5r2xEXyGhoExgbO++I=",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@azure/keyvault-common": {
+      "version": "2.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/keyvault-common/-/keyvault-common-2.0.0.tgz",
+      "integrity": "sha1-keUN8B2b+o9V8Qe7nNvFdYaysqQ=",
       "license": "MIT",
       "dependencies": {
-        "@azure/abort-controller": "^1.0.0",
+        "@azure/abort-controller": "^2.0.0",
+        "@azure/core-auth": "^1.3.0",
+        "@azure/core-client": "^1.5.0",
+        "@azure/core-rest-pipeline": "^1.8.0",
+        "@azure/core-tracing": "^1.0.0",
+        "@azure/core-util": "^1.10.0",
+        "@azure/logger": "^1.1.4",
+        "tslib": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/keyvault-keys": {
+      "version": "4.9.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/keyvault-keys/-/keyvault-keys-4.9.0.tgz",
+      "integrity": "sha1-g60jcEKdH1dubFxZ/xZXYeLY/qs=",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.0.0",
         "@azure/core-auth": "^1.3.0",
         "@azure/core-client": "^1.5.0",
         "@azure/core-http-compat": "^2.0.1",
@@ -387,6 +405,7 @@
         "@azure/core-rest-pipeline": "^1.8.1",
         "@azure/core-tracing": "^1.0.0",
         "@azure/core-util": "^1.0.0",
+        "@azure/keyvault-common": "^2.0.0",
         "@azure/logger": "^1.0.0",
         "tslib": "^2.2.0"
       },
@@ -394,22 +413,10 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@azure/keyvault-keys/node_modules/@azure/abort-controller": {
-      "version": "1.1.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/abort-controller/-/abort-controller-1.1.0.tgz",
-      "integrity": "sha1-eI7nhFelWvihrTQqyxgjg9IRkkk=",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
     "node_modules/@azure/logger": {
-      "version": "1.1.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/logger/-/logger-1.1.2.tgz",
-      "integrity": "sha1-P0uHbO+tMo3BSv+LhQ1jthHiSdw=",
+      "version": "1.1.4",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/logger/-/logger-1.1.4.tgz",
+      "integrity": "sha1-Ijy/K0JN+mZHjOmk9XX1nG83l2g=",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -419,33 +426,42 @@
       }
     },
     "node_modules/@azure/msal-browser": {
-      "version": "3.17.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/msal-browser/-/msal-browser-3.17.0.tgz",
-      "integrity": "sha1-3unMrlhiOefgcIsmH3/6W8fgD7c=",
+      "version": "4.4.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/msal-browser/-/msal-browser-4.4.0.tgz",
+      "integrity": "sha1-Ds/8oEMTT7p58Q69w/G4CJCDPKA=",
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-common": "14.12.0"
+        "@azure/msal-common": "15.2.0"
       },
       "engines": {
         "node": ">=0.8.0"
       }
     },
+    "node_modules/@azure/msal-browser/node_modules/@azure/msal-common": {
+      "version": "15.2.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/msal-common/-/msal-common-15.2.0.tgz",
+      "integrity": "sha1-9OOLqFwKMiCLcEbgEcIf9ie2dVw=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/@azure/msal-common": {
-      "version": "14.12.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/msal-common/-/msal-common-14.12.0.tgz",
-      "integrity": "sha1-hEq+JpsHH4+olJ2twqe2W7sUdYg=",
+      "version": "14.16.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/msal-common/-/msal-common-14.16.0.tgz",
+      "integrity": "sha1-80cPyux4jb5QhZlSzUmTQL2iPXo=",
       "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/@azure/msal-node": {
-      "version": "2.9.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/msal-node/-/msal-node-2.9.2.tgz",
-      "integrity": "sha1-5tPBZhASwb0O9o4yj3Oi/e3lKTE=",
+      "version": "2.16.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/msal-node/-/msal-node-2.16.2.tgz",
+      "integrity": "sha1-Prdo02iD6m+ak5wLW0Z7UY54//w=",
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-common": "14.12.0",
+        "@azure/msal-common": "14.16.0",
         "jsonwebtoken": "^9.0.0",
         "uuid": "^8.3.0"
       },
@@ -463,20 +479,20 @@
       }
     },
     "node_modules/@azure/opentelemetry-instrumentation-azure-sdk": {
-      "version": "1.0.0-beta.5",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/opentelemetry-instrumentation-azure-sdk/-/opentelemetry-instrumentation-azure-sdk-1.0.0-beta.5.tgz",
-      "integrity": "sha1-eICebABdCEUHAeXTfwh/b84vhus=",
+      "version": "1.0.0-beta.8",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/opentelemetry-instrumentation-azure-sdk/-/opentelemetry-instrumentation-azure-sdk-1.0.0-beta.8.tgz",
+      "integrity": "sha1-erxrBWNUQU5rrMNmhzxn+MvnGKo=",
       "license": "MIT",
       "dependencies": {
-        "@azure/core-tracing": "^1.0.0",
+        "@azure/core-tracing": "^1.2.0",
         "@azure/logger": "^1.0.0",
-        "@opentelemetry/api": "^1.4.1",
-        "@opentelemetry/core": "^1.15.2",
-        "@opentelemetry/instrumentation": "^0.41.2",
-        "tslib": "^2.2.0"
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/core": "^1.30.1",
+        "@opentelemetry/instrumentation": "^0.57.1",
+        "tslib": "^2.7.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@azure/service-bus": {
@@ -521,13 +537,14 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.24.7",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/code-frame/-/code-frame-7.24.7.tgz",
-      "integrity": "sha1-iC/Z4J6O4yTklr0EBAHG8EbvRGU=",
+      "version": "7.26.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/code-frame/-/code-frame-7.26.2.tgz",
+      "integrity": "sha1-S1+rl9MzOO/5FiNQVfDrwh5XOoU=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/highlight": "^7.24.7",
+        "@babel/helper-validator-identifier": "^7.25.9",
+        "js-tokens": "^4.0.0",
         "picocolors": "^1.0.0"
       },
       "engines": {
@@ -535,9 +552,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.24.7",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/compat-data/-/compat-data-7.24.7.tgz",
-      "integrity": "sha1-0ju+pQjDiDuoJR+0FkmCw26ld+0=",
+      "version": "7.26.8",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/compat-data/-/compat-data-7.26.8.tgz",
+      "integrity": "sha1-ghwdNWQcNVKE1KhwuKSnsMFB42c=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -545,22 +562,22 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.24.7",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/core/-/core-7.24.7.tgz",
-      "integrity": "sha1-tnZFAUHgtSo9Q7yR2oaqYI+VCsQ=",
+      "version": "7.26.9",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/core/-/core-7.26.9.tgz",
+      "integrity": "sha1-cYOFQqSx5J3+01PXrLxuuJ9KdvI=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
-        "@babel/code-frame": "^7.24.7",
-        "@babel/generator": "^7.24.7",
-        "@babel/helper-compilation-targets": "^7.24.7",
-        "@babel/helper-module-transforms": "^7.24.7",
-        "@babel/helpers": "^7.24.7",
-        "@babel/parser": "^7.24.7",
-        "@babel/template": "^7.24.7",
-        "@babel/traverse": "^7.24.7",
-        "@babel/types": "^7.24.7",
+        "@babel/code-frame": "^7.26.2",
+        "@babel/generator": "^7.26.9",
+        "@babel/helper-compilation-targets": "^7.26.5",
+        "@babel/helper-module-transforms": "^7.26.0",
+        "@babel/helpers": "^7.26.9",
+        "@babel/parser": "^7.26.9",
+        "@babel/template": "^7.26.9",
+        "@babel/traverse": "^7.26.9",
+        "@babel/types": "^7.26.9",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -576,13 +593,13 @@
       }
     },
     "node_modules/@babel/core/node_modules/debug": {
-      "version": "4.3.5",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/debug/-/debug-4.3.5.tgz",
-      "integrity": "sha1-6DRE7Ouf7dSh2lbWca4kRqAabh4=",
+      "version": "4.4.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha1-Kz8q6i/+t3ZHdGAmc3fchxD6uoo=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -594,9 +611,9 @@
       }
     },
     "node_modules/@babel/core/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
+      "version": "2.1.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI=",
       "dev": true,
       "license": "MIT"
     },
@@ -611,31 +628,32 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.24.7",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/generator/-/generator-7.24.7.tgz",
-      "integrity": "sha1-FlTQHeIK1mtLTZnBNUcbxlTFXm0=",
+      "version": "7.26.9",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/generator/-/generator-7.26.9.tgz",
+      "integrity": "sha1-dalIKtPQzHGIpTeqSRC8Wdtny8o=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.24.7",
+        "@babel/parser": "^7.26.9",
+        "@babel/types": "^7.26.9",
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25",
-        "jsesc": "^2.5.1"
+        "jsesc": "^3.0.2"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.24.7",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/helper-compilation-targets/-/helper-compilation-targets-7.24.7.tgz",
-      "integrity": "sha1-TrbEqA1v/qwlq4zZohtd+kjVA6k=",
+      "version": "7.26.5",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/helper-compilation-targets/-/helper-compilation-targets-7.26.5.tgz",
+      "integrity": "sha1-ddkruNjVEwHA1J5Splyaf+lFFNg=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.24.7",
-        "@babel/helper-validator-option": "^7.24.7",
-        "browserslist": "^4.22.2",
+        "@babel/compat-data": "^7.26.5",
+        "@babel/helper-validator-option": "^7.25.9",
+        "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
       },
@@ -653,72 +671,30 @@
         "semver": "bin/semver.js"
       }
     },
-    "node_modules/@babel/helper-environment-visitor": {
-      "version": "7.24.7",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/helper-environment-visitor/-/helper-environment-visitor-7.24.7.tgz",
-      "integrity": "sha1-SzG6lVHR+QeBuoNJHdWc+bJp99k=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.24.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-function-name": {
-      "version": "7.24.7",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/helper-function-name/-/helper-function-name-7.24.7.tgz",
-      "integrity": "sha1-dfHhcldC85rGWE7gsW2UUT2jjdI=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/template": "^7.24.7",
-        "@babel/types": "^7.24.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-hoist-variables": {
-      "version": "7.24.7",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/helper-hoist-variables/-/helper-hoist-variables-7.24.7.tgz",
-      "integrity": "sha1-tO3hzeL9iUNjl/MNyTdu4GsPJe4=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.24.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.24.7",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/helper-module-imports/-/helper-module-imports-7.24.7.tgz",
-      "integrity": "sha1-8vmAOS3luEwzKPxx04vYG7uDBCs=",
+      "version": "7.25.9",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/helper-module-imports/-/helper-module-imports-7.25.9.tgz",
+      "integrity": "sha1-5/jSBgLr2/nrvqCgdR+w8qQUFxU=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.24.7",
-        "@babel/types": "^7.24.7"
+        "@babel/traverse": "^7.25.9",
+        "@babel/types": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.24.7",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/helper-module-transforms/-/helper-module-transforms-7.24.7.tgz",
-      "integrity": "sha1-MbbJopMGeUmNtltoWxaYv9bH2vg=",
+      "version": "7.26.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/helper-module-transforms/-/helper-module-transforms-7.26.0.tgz",
+      "integrity": "sha1-jOVOydWSaV5Y2EzYhLe1xqL97q4=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-environment-visitor": "^7.24.7",
-        "@babel/helper-module-imports": "^7.24.7",
-        "@babel/helper-simple-access": "^7.24.7",
-        "@babel/helper-split-export-declaration": "^7.24.7",
-        "@babel/helper-validator-identifier": "^7.24.7"
+        "@babel/helper-module-imports": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.25.9",
+        "@babel/traverse": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -728,46 +704,19 @@
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.24.7",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.7.tgz",
-      "integrity": "sha1-mMhP5v49DTrnv8Ol4WakaET+sqA=",
+      "version": "7.26.5",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/helper-plugin-utils/-/helper-plugin-utils-7.26.5.tgz",
+      "integrity": "sha1-GFgNAMmTQRetcZOSxPZYXJMzzDU=",
       "dev": true,
       "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-simple-access": {
-      "version": "7.24.7",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/helper-simple-access/-/helper-simple-access-7.24.7.tgz",
-      "integrity": "sha1-vK3o2jrsjtFrnElTt05Qa1G17bM=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/traverse": "^7.24.7",
-        "@babel/types": "^7.24.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-split-export-declaration": {
-      "version": "7.24.7",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.24.7.tgz",
-      "integrity": "sha1-g5SUNokOB/o9aHPGGpbju/aS2FY=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.24.7"
-      },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.24.7",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/helper-string-parser/-/helper-string-parser-7.24.7.tgz",
-      "integrity": "sha1-TS0PFIIO3juYB+pfw238jNfaB/I=",
+      "version": "7.25.9",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
+      "integrity": "sha1-Gqu3Lucu01eJtLvK08ooYs5hTow=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -775,9 +724,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.24.7",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.7.tgz",
-      "integrity": "sha1-dbiJz6+eNcKq9Czw1yyOkXGSUds=",
+      "version": "7.25.9",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
+      "integrity": "sha1-JLZOLD7HzTs8VHcpuNFocfIsvcc=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -785,9 +734,9 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.24.7",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/helper-validator-option/-/helper-validator-option-7.24.7.tgz",
-      "integrity": "sha1-JMO7d8ekJdF0LuyPtDO1obOOYvY=",
+      "version": "7.25.9",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/helper-validator-option/-/helper-validator-option-7.25.9.tgz",
+      "integrity": "sha1-huRb2KSat+A/J2V3+WF5ZT1B2nI=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -795,119 +744,28 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.24.7",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/helpers/-/helpers-7.24.7.tgz",
-      "integrity": "sha1-qizNop9iGFrLXUL7SjobEIIQdBY=",
+      "version": "7.26.9",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/helpers/-/helpers-7.26.9.tgz",
+      "integrity": "sha1-KPP7RSUvyI7y3FR8ipEcJV/J/vY=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.24.7",
-        "@babel/types": "^7.24.7"
+        "@babel/template": "^7.26.9",
+        "@babel/types": "^7.26.9"
       },
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/highlight": {
-      "version": "7.24.7",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/highlight/-/highlight-7.24.7.tgz",
-      "integrity": "sha1-oFqx3xNLKGVYquDtQebF9zG/QJ0=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.24.7",
-        "chalk": "^2.4.2",
-        "js-tokens": "^4.0.0",
-        "picocolors": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha1-u3GFBpDh8TZWfeYp0tVHHe2kweg=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@babel/highlight/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.24.7",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/parser/-/parser-7.24.7.tgz",
-      "integrity": "sha1-mlIm+S8MXI6tVQt1D1YI52bIzoU=",
+      "version": "7.26.9",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/parser/-/parser-7.26.9.tgz",
+      "integrity": "sha1-2eeL7m3ID579jyNJ3Pu82s4oD9U=",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.26.9"
+      },
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -954,6 +812,38 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/plugin-syntax-class-static-block": {
+      "version": "7.14.5",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz",
+      "integrity": "sha1-GV34mxRrS3izv4l/16JXyEZZ1AY=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-import-attributes": {
+      "version": "7.26.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.26.0.tgz",
+      "integrity": "sha1-OxQShHaZ7qc5tPJgLHTONvawsPc=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
     "node_modules/@babel/plugin-syntax-import-meta": {
       "version": "7.10.4",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
@@ -981,13 +871,13 @@
       }
     },
     "node_modules/@babel/plugin-syntax-jsx": {
-      "version": "7.24.7",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.24.7.tgz",
-      "integrity": "sha1-OaH6Sn49PX804qzGvlhbcY0w4C0=",
+      "version": "7.25.9",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.25.9.tgz",
+      "integrity": "sha1-o0MToXjqVvGVFZm5KcHOrO5xkpA=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.24.7"
+        "@babel/helper-plugin-utils": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1074,6 +964,22 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/plugin-syntax-private-property-in-object": {
+      "version": "7.14.5",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz",
+      "integrity": "sha1-DcZnHsDqIrbpShEU+FeXDNOd4a0=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
     "node_modules/@babel/plugin-syntax-top-level-await": {
       "version": "7.14.5",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
@@ -1091,13 +997,13 @@
       }
     },
     "node_modules/@babel/plugin-syntax-typescript": {
-      "version": "7.24.7",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.24.7.tgz",
-      "integrity": "sha1-WNRYJxtNO2uyfuaslSWsuyWbrRw=",
+      "version": "7.25.9",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.25.9.tgz",
+      "integrity": "sha1-Z92it02kNyfPIdRs+a/vI/Q2U5k=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.24.7"
+        "@babel/helper-plugin-utils": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1107,35 +1013,32 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.24.7",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/template/-/template-7.24.7.tgz",
-      "integrity": "sha1-Au/O4xfQYJ0sBxF8tw74+xercxU=",
+      "version": "7.26.9",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/template/-/template-7.26.9.tgz",
+      "integrity": "sha1-RXetPd9D0ZRSjP9OH6ayMvpgm7I=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.24.7",
-        "@babel/parser": "^7.24.7",
-        "@babel/types": "^7.24.7"
+        "@babel/code-frame": "^7.26.2",
+        "@babel/parser": "^7.26.9",
+        "@babel/types": "^7.26.9"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.24.7",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/traverse/-/traverse-7.24.7.tgz",
-      "integrity": "sha1-3iuQAWP6dBchujghY/5GqTbEDPU=",
+      "version": "7.26.9",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/traverse/-/traverse-7.26.9.tgz",
+      "integrity": "sha1-Q5jyOUumbQXZiLKtE8IZoshXRho=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.24.7",
-        "@babel/generator": "^7.24.7",
-        "@babel/helper-environment-visitor": "^7.24.7",
-        "@babel/helper-function-name": "^7.24.7",
-        "@babel/helper-hoist-variables": "^7.24.7",
-        "@babel/helper-split-export-declaration": "^7.24.7",
-        "@babel/parser": "^7.24.7",
-        "@babel/types": "^7.24.7",
+        "@babel/code-frame": "^7.26.2",
+        "@babel/generator": "^7.26.9",
+        "@babel/parser": "^7.26.9",
+        "@babel/template": "^7.26.9",
+        "@babel/types": "^7.26.9",
         "debug": "^4.3.1",
         "globals": "^11.1.0"
       },
@@ -1144,13 +1047,13 @@
       }
     },
     "node_modules/@babel/traverse/node_modules/debug": {
-      "version": "4.3.5",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/debug/-/debug-4.3.5.tgz",
-      "integrity": "sha1-6DRE7Ouf7dSh2lbWca4kRqAabh4=",
+      "version": "4.4.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha1-Kz8q6i/+t3ZHdGAmc3fchxD6uoo=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -1172,22 +1075,21 @@
       }
     },
     "node_modules/@babel/traverse/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
+      "version": "2.1.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@babel/types": {
-      "version": "7.24.7",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/types/-/types-7.24.7.tgz",
-      "integrity": "sha1-YCf+ErwapyTNMqsRP7fxmI8fZvI=",
+      "version": "7.26.9",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/types/-/types-7.26.9.tgz",
+      "integrity": "sha1-CLQ97HnujmgsKsYxwBC9ysVKIc4=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.24.7",
-        "@babel/helper-validator-identifier": "^7.24.7",
-        "to-fast-properties": "^2.0.0"
+        "@babel/helper-string-parser": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1221,18 +1123,33 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.4.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
-      "integrity": "sha1-ojUU6Pua8SadX3eIqlVnmNYca1k=",
+      "version": "4.4.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@eslint-community/eslint-utils/-/eslint-utils-4.4.1.tgz",
+      "integrity": "sha1-0RRb8sIBMtZABJXW30v1k2L9nVY=",
       "license": "MIT",
       "dependencies": {
-        "eslint-visitor-keys": "^3.3.0"
+        "eslint-visitor-keys": "^3.4.3"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
       "peerDependencies": {
         "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha1-DNcv6FUOPC6uFWqWpN3c0cisWAA=",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/@eslint-community/regexpp": {
@@ -1245,12 +1162,12 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.19.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@eslint/config-array/-/config-array-0.19.1.tgz",
-      "integrity": "sha1-c0quosQL4iu7HyqdrGh8V6akyYQ=",
+      "version": "0.19.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@eslint/config-array/-/config-array-0.19.2.tgz",
+      "integrity": "sha1-MGC4CeERq/yXrbC7EXJ3i5DLRqo=",
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/object-schema": "^2.1.5",
+        "@eslint/object-schema": "^2.1.6",
         "debug": "^4.3.1",
         "minimatch": "^3.1.2"
       },
@@ -1282,9 +1199,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/core": {
-      "version": "0.9.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@eslint/core/-/core-0.9.1.tgz",
-      "integrity": "sha1-MXY4RzCO9rcISkUFVzrJQCxR+dE=",
+      "version": "0.12.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@eslint/core/-/core-0.12.0.tgz",
+      "integrity": "sha1-X5YMPVdyi+n2xlvYSqaqYTB4eY4=",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/json-schema": "^7.0.15"
@@ -1294,9 +1211,9 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "3.2.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@eslint/eslintrc/-/eslintrc-3.2.0.tgz",
-      "integrity": "sha1-V0cKxOLig6a/dgRNYygRluNwVCw=",
+      "version": "3.3.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@eslint/eslintrc/-/eslintrc-3.3.0.tgz",
+      "integrity": "sha1-lqVY9FhCmJzKfqHs14WtVJEZOEY=",
       "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.4",
@@ -1352,29 +1269,30 @@
       "license": "MIT"
     },
     "node_modules/@eslint/js": {
-      "version": "9.17.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@eslint/js/-/js-9.17.0.tgz",
-      "integrity": "sha1-FSPlhnkfgDdqb4OYo5ZEVezGUew=",
+      "version": "9.21.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@eslint/js/-/js-9.21.0.tgz",
+      "integrity": "sha1-QwPvTgcibYfDlbj61SeHY+nBXAg=",
       "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@eslint/object-schema": {
-      "version": "2.1.5",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@eslint/object-schema/-/object-schema-2.1.5.tgz",
-      "integrity": "sha1-hnCo9iWKK+WyxiD/MUodmEwj6y4=",
+      "version": "2.1.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@eslint/object-schema/-/object-schema-2.1.6.tgz",
+      "integrity": "sha1-WDaatbWzyhF4gMD2wLDzL2lQ8k8=",
       "license": "Apache-2.0",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.2.4",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@eslint/plugin-kit/-/plugin-kit-0.2.4.tgz",
-      "integrity": "sha1-K3jnuzdVeEuxP6qJMqHZlNZTd5I=",
+      "version": "0.2.7",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@eslint/plugin-kit/-/plugin-kit-0.2.7.tgz",
+      "integrity": "sha1-mQHVLBNvuPN1kGpz3MOCZGw7aic=",
       "license": "Apache-2.0",
       "dependencies": {
+        "@eslint/core": "^0.12.0",
         "levn": "^0.4.1"
       },
       "engines": {
@@ -1473,9 +1391,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@humanwhocodes/retry": {
-      "version": "0.4.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@humanwhocodes/retry/-/retry-0.4.1.tgz",
-      "integrity": "sha1-mpbOUBvGLfRsQDH72XDjzGsQ8Hs=",
+      "version": "0.4.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@humanwhocodes/retry/-/retry-0.4.2.tgz",
+      "integrity": "sha1-GGBHPeffoVRnZ0SPMz24DLD/IWE=",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18"
@@ -1908,9 +1826,9 @@
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.5",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
-      "integrity": "sha1-3M5q/3S99trRqVgCtpsEovyx+zY=",
+      "version": "0.3.8",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz",
+      "integrity": "sha1-Tw4GNi4BNi+CPTSPGHKwj2ZtgUI=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1943,9 +1861,9 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.4.15",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-      "integrity": "sha1-18bmdVx4VnqVHgSrUu8P0m3lnzI=",
+      "version": "1.5.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+      "integrity": "sha1-MYi8snOkFLDSFf0ipYVAuYm5QJo=",
       "dev": true,
       "license": "MIT"
     },
@@ -1961,9 +1879,9 @@
       }
     },
     "node_modules/@js-joda/core": {
-      "version": "5.6.3",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@js-joda/core/-/core-5.6.3.tgz",
-      "integrity": "sha1-Qa4cB94evg9t3hq8vJcAoJucYFY=",
+      "version": "5.6.4",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@js-joda/core/-/core-5.6.4.tgz",
+      "integrity": "sha1-q6/OmzAwJjm/5KcbrVEg/jllTxA=",
       "license": "BSD-3-Clause"
     },
     "node_modules/@microsoft/applicationinsights-web-snippet": {
@@ -1979,6 +1897,7 @@
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -1991,6 +1910,7 @@
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -2003,6 +1923,7 @@
       "cpu": [
         "arm"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -2015,6 +1936,7 @@
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -2027,6 +1949,7 @@
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -2039,6 +1962,7 @@
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -2088,13 +2012,25 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/@opentelemetry/core": {
-      "version": "1.25.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@opentelemetry/core/-/core-1.25.1.tgz",
-      "integrity": "sha1-/2Z9k50Sit/Hx5Ptri9ryhd/gp0=",
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.57.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@opentelemetry/api-logs/-/api-logs-0.57.2.tgz",
+      "integrity": "sha1-1AAbmqNYA2e0D+iJ81QAFPdmzIc=",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.25.1"
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "1.30.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@opentelemetry/core/-/core-1.30.1.tgz",
+      "integrity": "sha1-oLRouzljWN+AGIFwnqOCmfwwqyc=",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.28.0"
       },
       "engines": {
         "node": ">=14"
@@ -2103,16 +2039,26 @@
         "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
+    "node_modules/@opentelemetry/core/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.28.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha1-M3+yvKBFPQcmaW50X1AGRBH2RtY=",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@opentelemetry/instrumentation": {
-      "version": "0.41.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@opentelemetry/instrumentation/-/instrumentation-0.41.2.tgz",
-      "integrity": "sha1-yuEfpkSF3PA9rjMfNbMVtkvGGJ8=",
+      "version": "0.57.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@opentelemetry/instrumentation/-/instrumentation-0.57.2.tgz",
+      "integrity": "sha1-iSRUnXlBuhtcbwTVUpz0gzBFbR0=",
       "license": "Apache-2.0",
       "dependencies": {
-        "@types/shimmer": "^1.0.2",
-        "import-in-the-middle": "1.4.2",
+        "@opentelemetry/api-logs": "0.57.2",
+        "@types/shimmer": "^1.2.0",
+        "import-in-the-middle": "^1.8.1",
         "require-in-the-middle": "^7.1.1",
-        "semver": "^7.5.1",
+        "semver": "^7.5.2",
         "shimmer": "^1.2.1"
       },
       "engines": {
@@ -2123,30 +2069,39 @@
       }
     },
     "node_modules/@opentelemetry/resources": {
-      "version": "1.25.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@opentelemetry/resources/-/resources-1.25.1.tgz",
-      "integrity": "sha1-u5pnSvJaGmwwhAt1W8adonlv77s=",
+      "version": "1.30.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@opentelemetry/resources/-/resources-1.30.1.tgz",
+      "integrity": "sha1-pOrhfr2WlH/cemT5McpLceGM6WQ=",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.25.1",
-        "@opentelemetry/semantic-conventions": "1.25.1"
+        "@opentelemetry/core": "1.30.1",
+        "@opentelemetry/semantic-conventions": "1.28.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.28.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha1-M3+yvKBFPQcmaW50X1AGRBH2RtY=",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "1.25.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.25.1.tgz",
-      "integrity": "sha1-y8HmCvJVZV0gIKoUzeF7N70T3zc=",
+      "version": "1.30.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.30.1.tgz",
+      "integrity": "sha1-QaQiNAltyY6PRU0kVR/IC4Fv6zQ=",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.25.1",
-        "@opentelemetry/resources": "1.25.1",
-        "@opentelemetry/semantic-conventions": "1.25.1"
+        "@opentelemetry/core": "1.30.1",
+        "@opentelemetry/resources": "1.30.1",
+        "@opentelemetry/semantic-conventions": "1.28.0"
       },
       "engines": {
         "node": ">=14"
@@ -2155,10 +2110,19 @@
         "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
+    "node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.28.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha1-M3+yvKBFPQcmaW50X1AGRBH2RtY=",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.25.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@opentelemetry/semantic-conventions/-/semantic-conventions-1.25.1.tgz",
-      "integrity": "sha1-De7LOGGXxenCwo8vifUfuK6fFF4=",
+      "version": "1.30.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@opentelemetry/semantic-conventions/-/semantic-conventions-1.30.0.tgz",
+      "integrity": "sha1-OkLExHVILy7IfBKq2Ygy3ACH3Jo=",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
@@ -2189,15 +2153,6 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
-      }
-    },
-    "node_modules/@tootallnate/once": {
-      "version": "2.0.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@tootallnate/once/-/once-2.0.0.tgz",
-      "integrity": "sha1-9UShSNOrNYAcH2M6dEH9h8LkhL8=",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10"
       }
     },
     "node_modules/@types/babel__core": {
@@ -2245,27 +2200,6 @@
         "@babel/types": "^7.20.7"
       }
     },
-    "node_modules/@types/body-parser": {
-      "version": "1.19.5",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/body-parser/-/body-parser-1.19.5.tgz",
-      "integrity": "sha1-BM6aO2d9yL1oGhfaGrmDXcnT7eQ=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/connect": "*",
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/connect": {
-      "version": "3.4.38",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/connect/-/connect-3.4.38.tgz",
-      "integrity": "sha1-W6fzvE+73q/43e2VLl/yzFP42Fg=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/debug": {
       "version": "4.1.12",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/debug/-/debug-4.1.12.tgz",
@@ -2281,32 +2215,6 @@
       "integrity": "sha1-Yo7/7q4gZKG055946B2Ht+X8e1A=",
       "license": "MIT"
     },
-    "node_modules/@types/express": {
-      "version": "4.17.21",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/express/-/express-4.17.21.tgz",
-      "integrity": "sha1-wm1KFR5g7+AISyPcM2nrxjHtGS0=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/body-parser": "*",
-        "@types/express-serve-static-core": "^4.17.33",
-        "@types/qs": "*",
-        "@types/serve-static": "*"
-      }
-    },
-    "node_modules/@types/express-serve-static-core": {
-      "version": "4.19.5",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/express-serve-static-core/-/express-serve-static-core-4.19.5.tgz",
-      "integrity": "sha1-IYBk4yESb8+QSNHKJd0kZdpV2cY=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "@types/qs": "*",
-        "@types/range-parser": "*",
-        "@types/send": "*"
-      }
-    },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.9",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
@@ -2316,13 +2224,6 @@
       "dependencies": {
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/http-errors": {
-      "version": "2.0.4",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/http-errors/-/http-errors-2.0.4.tgz",
-      "integrity": "sha1-frR3JsORtzRabsNa1/TeRpz1uk8=",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/is-buffer": {
       "version": "2.0.2",
@@ -2366,46 +2267,25 @@
       "integrity": "sha1-WWoXRyM2lNUPatinhp/Lb1bPWEE=",
       "license": "MIT"
     },
-    "node_modules/@types/mime": {
-      "version": "1.3.5",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/mime/-/mime-1.3.5.tgz",
-      "integrity": "sha1-HvMC4Bz30rWg+lJnkMkSO/HQZpA=",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/ms": {
-      "version": "0.7.34",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/ms/-/ms-0.7.34.tgz",
-      "integrity": "sha1-EJZLoN7mrEzUYuJ5W2vr1AcwNDM=",
+      "version": "2.1.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha1-BSqmekjszEMJ1/AZG35BQ0uQu3g=",
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.14.8",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/node/-/node-20.14.8.tgz",
-      "integrity": "sha1-RcJqKl3ibDU0qVBFMN2zsnzgMaw=",
+      "version": "22.13.5",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/node/-/node-22.13.5.tgz",
+      "integrity": "sha1-I63R1xrN2rLGpNMduJwPmNMwtRE=",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~6.20.0"
       }
     },
-    "node_modules/@types/qs": {
-      "version": "6.9.15",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/qs/-/qs-6.9.15.tgz",
-      "integrity": "sha1-rd6KBg7JwwWoLeG6vBBW5zvWTc4=",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/range-parser": {
-      "version": "1.2.7",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/range-parser/-/range-parser-1.2.7.tgz",
-      "integrity": "sha1-UK5DU+qt3AQEQnmBL1LIxlhX28s=",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/readable-stream": {
-      "version": "4.0.14",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/readable-stream/-/readable-stream-4.0.14.tgz",
-      "integrity": "sha1-WnagDh491v+SHqKz+sdIXFpJLBk=",
+      "version": "4.0.18",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/readable-stream/-/readable-stream-4.0.18.tgz",
+      "integrity": "sha1-XY0V0mx3ZQDOVzyuWAeH0UmCO/w=",
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -2418,33 +2298,10 @@
       "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
       "license": "MIT"
     },
-    "node_modules/@types/send": {
-      "version": "0.17.4",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/send/-/send-0.17.4.tgz",
-      "integrity": "sha1-ZhnNJOcnB5NwLk5qS5WKkBDPxXo=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/mime": "^1",
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/serve-static": {
-      "version": "1.15.7",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/serve-static/-/serve-static-1.15.7.tgz",
-      "integrity": "sha1-IhdLvXT7l/4wMQlzjptcLzBk9xQ=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/http-errors": "*",
-        "@types/node": "*",
-        "@types/send": "*"
-      }
-    },
     "node_modules/@types/shimmer": {
-      "version": "1.0.5",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/shimmer/-/shimmer-1.0.5.tgz",
-      "integrity": "sha1-SR2JhNRRDlUL/rAtUYeR1/WdK4g=",
+      "version": "1.2.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/shimmer/-/shimmer-1.2.0.tgz",
+      "integrity": "sha1-m3Bq+W+gZBaCiEI5enDfu/HBTe0=",
       "license": "MIT"
     },
     "node_modules/@types/stack-utils": {
@@ -2461,15 +2318,15 @@
       "license": "MIT"
     },
     "node_modules/@types/validator": {
-      "version": "13.12.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/validator/-/validator-13.12.0.tgz",
-      "integrity": "sha1-H+TDrp3lz1GTzmRxfJnvL6fYdW8=",
+      "version": "13.12.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/validator/-/validator-13.12.2.tgz",
+      "integrity": "sha1-dgMp51bhikqrgvxQK1Hr3+u+SfU=",
       "license": "MIT"
     },
     "node_modules/@types/yargs": {
-      "version": "17.0.32",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/yargs/-/yargs-17.0.32.tgz",
-      "integrity": "sha1-Awd0cjovf6r+v2RfTlpINx3KYik=",
+      "version": "17.0.33",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/yargs/-/yargs-17.0.33.tgz",
+      "integrity": "sha1-jDIwPag+7AUKhLPHrnufki0T4y0=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2484,14 +2341,14 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.19.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@typescript-eslint/scope-manager/-/scope-manager-8.19.1.tgz",
-      "integrity": "sha1-eUz8it1PNzuc1voy42fnVloOIxs=",
+      "version": "8.24.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@typescript-eslint/scope-manager/-/scope-manager-8.24.1.tgz",
+      "integrity": "sha1-Hh527EVgqoUHerNt65sr6tSuEk4=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.19.1",
-        "@typescript-eslint/visitor-keys": "8.19.1"
+        "@typescript-eslint/types": "8.24.1",
+        "@typescript-eslint/visitor-keys": "8.24.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2502,9 +2359,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.19.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@typescript-eslint/types/-/types-8.19.1.tgz",
-      "integrity": "sha1-AVqZEoF1TtmG8uVJJjoRiNbtCow=",
+      "version": "8.24.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@typescript-eslint/types/-/types-8.24.1.tgz",
+      "integrity": "sha1-h3egJPOvxKzl5I+agEMJxt04+Vo=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2516,20 +2373,20 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.19.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@typescript-eslint/typescript-estree/-/typescript-estree-8.19.1.tgz",
-      "integrity": "sha1-wQlLsAvCUax2zyFVaconI2Q1A2s=",
+      "version": "8.24.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@typescript-eslint/typescript-estree/-/typescript-estree-8.24.1.tgz",
+      "integrity": "sha1-O7R5QB+L1HGzxt09uJ5yVpd8VNs=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.19.1",
-        "@typescript-eslint/visitor-keys": "8.19.1",
+        "@typescript-eslint/types": "8.24.1",
+        "@typescript-eslint/visitor-keys": "8.24.1",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
         "minimatch": "^9.0.4",
         "semver": "^7.6.0",
-        "ts-api-utils": "^2.0.0"
+        "ts-api-utils": "^2.0.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2594,16 +2451,16 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.19.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@typescript-eslint/utils/-/utils-8.19.1.tgz",
-      "integrity": "sha1-3Y6r1GuSv2HlcyhuHAumvSQ6GFs=",
+      "version": "8.24.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@typescript-eslint/utils/-/utils-8.24.1.tgz",
+      "integrity": "sha1-CNFOrDPPs0Vv7u5aJ1uK0zSeUu0=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
-        "@typescript-eslint/scope-manager": "8.19.1",
-        "@typescript-eslint/types": "8.19.1",
-        "@typescript-eslint/typescript-estree": "8.19.1"
+        "@typescript-eslint/scope-manager": "8.24.1",
+        "@typescript-eslint/types": "8.24.1",
+        "@typescript-eslint/typescript-estree": "8.24.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2618,13 +2475,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.19.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@typescript-eslint/visitor-keys/-/visitor-keys-8.19.1.tgz",
-      "integrity": "sha1-/OVNfPpTUakjh9bAxb5ZjK7gcuA=",
+      "version": "8.24.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@typescript-eslint/visitor-keys/-/visitor-keys-8.24.1.tgz",
+      "integrity": "sha1-i9/keokZU0SzTrIe9hJRViFIICs=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.19.1",
+        "@typescript-eslint/types": "8.24.1",
         "eslint-visitor-keys": "^4.2.0"
       },
       "engines": {
@@ -2635,23 +2492,10 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
-      "version": "4.2.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
-      "integrity": "sha1-aHussq+IT83aim59ZcYG9GoUzUU=",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
     "node_modules/@ungap/structured-clone": {
-      "version": "1.2.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@ungap/structured-clone/-/structured-clone-1.2.1.tgz",
-      "integrity": "sha1-KPoYX2far3t6GowdRFEyxdl5+L0=",
+      "version": "1.3.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+      "integrity": "sha1-0Gu7OE689sUF/eHD0O1N3/4Kr/g=",
       "license": "ISC"
     },
     "node_modules/abort-controller": {
@@ -2691,10 +2535,10 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/acorn-import-assertions": {
-      "version": "1.9.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz",
-      "integrity": "sha1-UHJ2JJ1oR5fITgc074SGAzTPsaw=",
+    "node_modules/acorn-import-attributes": {
+      "version": "1.9.5",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
+      "integrity": "sha1-frFVexugXvGLXtDsZ1kb+rBGiO8=",
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^8"
@@ -2710,39 +2554,13 @@
       }
     },
     "node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha1-Sf/1hXfP7j83F2/qtMIuAPhtf3c=",
+      "version": "7.1.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/agent-base/-/agent-base-7.1.3.tgz",
+      "integrity": "sha1-KUNeuCG8QZRjOluJ5bxHA7r8JaE=",
       "license": "MIT",
-      "dependencies": {
-        "debug": "4"
-      },
       "engines": {
-        "node": ">= 6.0.0"
+        "node": ">= 14"
       }
-    },
-    "node_modules/agent-base/node_modules/debug": {
-      "version": "4.3.5",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/debug/-/debug-4.3.5.tgz",
-      "integrity": "sha1-6DRE7Ouf7dSh2lbWca4kRqAabh4=",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/agent-base/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
-      "license": "MIT"
     },
     "node_modules/agentkeepalive": {
       "version": "4.6.0",
@@ -2788,19 +2606,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/ansi-escapes/node_modules/type-fest": {
-      "version": "0.21.3",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/type-fest/-/type-fest-0.21.3.tgz",
-      "integrity": "sha1-0mCiSwGYQ24TP6JqUkptZfo7Ljc=",
-      "dev": true,
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -2840,14 +2645,13 @@
       }
     },
     "node_modules/applicationinsights": {
-      "version": "2.9.5",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/applicationinsights/-/applicationinsights-2.9.5.tgz",
-      "integrity": "sha1-NLz3GtWWchxSCYeiUuQNdJWqNQM=",
+      "version": "2.9.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/applicationinsights/-/applicationinsights-2.9.6.tgz",
+      "integrity": "sha1-Z1KOZn15U8jdV7X7FuCkcU/Aeu0=",
       "license": "MIT",
       "dependencies": {
-        "@azure/core-auth": "^1.5.0",
-        "@azure/core-rest-pipeline": "1.10.1",
-        "@azure/core-util": "1.2.0",
+        "@azure/core-auth": "1.7.2",
+        "@azure/core-rest-pipeline": "1.16.3",
         "@azure/opentelemetry-instrumentation-azure-sdk": "^1.0.0-beta.5",
         "@microsoft/applicationinsights-web-snippet": "1.0.1",
         "@opentelemetry/api": "^1.7.0",
@@ -2900,9 +2704,9 @@
       }
     },
     "node_modules/async": {
-      "version": "3.2.5",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/async/-/async-3.2.5.tgz",
-      "integrity": "sha1-69Uqj9r3oiiaJN85n42Ehcika2Y=",
+      "version": "3.2.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/async/-/async-3.2.6.tgz",
+      "integrity": "sha1-Gwco4Ukp1RuFtEm38G4nwRReOM4=",
       "license": "MIT"
     },
     "node_modules/async-hook-jl": {
@@ -2943,6 +2747,7 @@
       "version": "0.4.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/babel-jest": {
@@ -3028,24 +2833,27 @@
       }
     },
     "node_modules/babel-preset-current-node-syntax": {
-      "version": "1.0.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.0.1.tgz",
-      "integrity": "sha1-tDmSObibKgEfndvj5PQB/EDP9zs=",
+      "version": "1.1.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.1.0.tgz",
+      "integrity": "sha1-mpKer+zkGWEu9K5PYLGGLrrY7zA=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/plugin-syntax-async-generators": "^7.8.4",
         "@babel/plugin-syntax-bigint": "^7.8.3",
-        "@babel/plugin-syntax-class-properties": "^7.8.3",
-        "@babel/plugin-syntax-import-meta": "^7.8.3",
+        "@babel/plugin-syntax-class-properties": "^7.12.13",
+        "@babel/plugin-syntax-class-static-block": "^7.14.5",
+        "@babel/plugin-syntax-import-attributes": "^7.24.7",
+        "@babel/plugin-syntax-import-meta": "^7.10.4",
         "@babel/plugin-syntax-json-strings": "^7.8.3",
-        "@babel/plugin-syntax-logical-assignment-operators": "^7.8.3",
+        "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
         "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
-        "@babel/plugin-syntax-numeric-separator": "^7.8.3",
+        "@babel/plugin-syntax-numeric-separator": "^7.10.4",
         "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
         "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
         "@babel/plugin-syntax-optional-chaining": "^7.8.3",
-        "@babel/plugin-syntax-top-level-await": "^7.8.3"
+        "@babel/plugin-syntax-private-property-in-object": "^7.14.5",
+        "@babel/plugin-syntax-top-level-await": "^7.14.5"
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0"
@@ -3123,9 +2931,9 @@
       "license": "CC0-1.0"
     },
     "node_modules/bl": {
-      "version": "6.0.13",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/bl/-/bl-6.0.13.tgz",
-      "integrity": "sha1-3F8ojT+El3G7YRKylHer7kwKnZY=",
+      "version": "6.0.19",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/bl/-/bl-6.0.19.tgz",
+      "integrity": "sha1-xEhygrsYdoGG8C/sa+G+O1uTZ3s=",
       "license": "MIT",
       "dependencies": {
         "@types/readable-stream": "^4.0.0",
@@ -3188,9 +2996,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.23.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/browserslist/-/browserslist-4.23.1.tgz",
-      "integrity": "sha1-zkrwU0s9N9tcGkypi5CA+YUEHpY=",
+      "version": "4.24.4",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/browserslist/-/browserslist-4.24.4.tgz",
+      "integrity": "sha1-xrKGWj8IvLhgoOgnOJADuf5obks=",
       "dev": true,
       "funding": [
         {
@@ -3208,10 +3016,10 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "caniuse-lite": "^1.0.30001629",
-        "electron-to-chromium": "^1.4.796",
-        "node-releases": "^2.0.14",
-        "update-browserslist-db": "^1.0.16"
+        "caniuse-lite": "^1.0.30001688",
+        "electron-to-chromium": "^1.5.73",
+        "node-releases": "^2.0.19",
+        "update-browserslist-db": "^1.1.1"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -3268,9 +3076,10 @@
       "license": "MIT"
     },
     "node_modules/bullmq": {
-      "version": "5.34.10",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/bullmq/-/bullmq-5.34.10.tgz",
-      "integrity": "sha1-mo0woHHLtBPMHV1HiHlyHVT0nLI=",
+      "version": "5.41.5",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/bullmq/-/bullmq-5.41.5.tgz",
+      "integrity": "sha1-da6GxKYwQcVR1J3fT4NQjFboy14=",
+      "license": "MIT",
       "dependencies": {
         "cron-parser": "^4.9.0",
         "ioredis": "^5.4.1",
@@ -3292,6 +3101,21 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/bundle-name": {
+      "version": "4.1.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha1-87lrNBYNZDGhnXaIE1r3z7h5eIk=",
+      "license": "MIT",
+      "dependencies": {
+        "run-applescript": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/bunyan": {
@@ -3356,17 +3180,27 @@
       "integrity": "sha1-m7knkNnA7/7GO+c1GeEaNQGaOnI=",
       "license": "ISC"
     },
-    "node_modules/call-bind": {
-      "version": "1.0.7",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/call-bind/-/call-bind-1.0.7.tgz",
-      "integrity": "sha1-BgFlmcQMVkmMGHadJzC+JCtvo7k=",
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha1-S1QowiK+mF15w9gmV0edvgtZstY=",
       "license": "MIT",
       "dependencies": {
-        "es-define-property": "^1.0.0",
         "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2",
-        "get-intrinsic": "^1.2.4",
-        "set-function-length": "^1.2.1"
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/call-bound/-/call-bound-1.0.3.tgz",
+      "integrity": "sha1-Qc/QMrWT45F2pxUzq084SqBP1oE=",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "get-intrinsic": "^1.2.6"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3395,9 +3229,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001636",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/caniuse-lite/-/caniuse-lite-1.0.30001636.tgz",
-      "integrity": "sha1-sV9S0r25X60ywvU8C2gDK4UYing=",
+      "version": "1.0.30001700",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/caniuse-lite/-/caniuse-lite-1.0.30001700.tgz",
+      "integrity": "sha1-Js1CnPCbT9TnRdr0kWA5x5TXIPY=",
       "dev": true,
       "funding": [
         {
@@ -3496,9 +3330,9 @@
       }
     },
     "node_modules/cjs-module-lexer": {
-      "version": "1.3.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/cjs-module-lexer/-/cjs-module-lexer-1.3.1.tgz",
-      "integrity": "sha1-xIU0Guj9mZyk7lry16HJrgHgCZw=",
+      "version": "1.4.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
+      "integrity": "sha1-D3lzHrjP4exyrNQGbvrJ1hmRsA0=",
       "license": "MIT"
     },
     "node_modules/cli-cursor": {
@@ -3534,60 +3368,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/cli-truncate/node_modules/ansi-regex": {
-      "version": "6.1.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ansi-regex/-/ansi-regex-6.1.0.tgz",
-      "integrity": "sha1-lexAnGlhnWyxuLNPFLZg7yjr1lQ=",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/cli-truncate/node_modules/emoji-regex": {
-      "version": "10.4.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/emoji-regex/-/emoji-regex-10.4.0.tgz",
-      "integrity": "sha1-A1U6/qgLOXV0nPyzb3dsomjkE9Q=",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/cli-truncate/node_modules/string-width": {
-      "version": "7.2.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/string-width/-/string-width-7.2.0.tgz",
-      "integrity": "sha1-tbuOIWXOJ11NQ0dt0nAK2Qkdttw=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^10.3.0",
-        "get-east-asian-width": "^1.0.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/cli-truncate/node_modules/strip-ansi": {
-      "version": "7.1.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/strip-ansi/-/strip-ansi-7.1.0.tgz",
-      "integrity": "sha1-1bZWjKaJ2FYTcLBwdoXSJDT6/0U=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
     "node_modules/cliui": {
       "version": "8.0.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/cliui/-/cliui-8.0.1.tgz",
@@ -3601,6 +3381,56 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/cliui/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc=",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cliui/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha1-JpxxF9J7Ba0uU2gwqOyJXvnG0BA=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha1-Z+FFz/UQpqaYS98RUpEdadLrnkM=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/clone": {
@@ -3736,6 +3566,7 @@
       "version": "1.0.8",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha1-w9RaizT9cwYxoRCoolIGgrMdWn8=",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
@@ -3745,9 +3576,9 @@
       }
     },
     "node_modules/commander": {
-      "version": "12.1.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/commander/-/commander-12.1.0.tgz",
-      "integrity": "sha1-AUI7NvUBJZ/arE0OTWDJbJkVhdM=",
+      "version": "13.1.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha1-d2Fn22jHjzjczh+bjXuLmkiKv0Y=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3812,6 +3643,7 @@
       "version": "0.7.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/cookie/-/cookie-0.7.1.tgz",
       "integrity": "sha1-L3PEIULV1c9xMQp0/ErmFnDl28k=",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -3861,6 +3693,7 @@
       "version": "4.9.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/cron-parser/-/cron-parser-4.9.0.tgz",
       "integrity": "sha1-A0BpSvPkagiUl4xvUqbbtcDxGtU=",
+      "license": "MIT",
       "dependencies": {
         "luxon": "^3.2.1"
       },
@@ -3872,6 +3705,7 @@
       "version": "7.0.6",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha1-ilj+ePANzXDDcEUXWd+/rwPo7p8=",
+      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -3921,36 +3755,51 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/define-data-property": {
-      "version": "1.1.4",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/define-data-property/-/define-data-property-1.1.4.tgz",
-      "integrity": "sha1-iU3BQbt9MGCuQ2b2oBB+aPvkjF4=",
+    "node_modules/default-browser": {
+      "version": "5.2.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/default-browser/-/default-browser-5.2.1.tgz",
+      "integrity": "sha1-e3umEgT/PkJbVWhprm0+nZ8XEs8=",
       "license": "MIT",
       "dependencies": {
-        "es-define-property": "^1.0.0",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.0.1"
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
       },
       "engines": {
-        "node": ">= 0.4"
+        "node": ">=18"
       },
       "funding": {
-        "url": "https://github.com/sponsors/ljharb"
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "5.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/default-browser-id/-/default-browser-id-5.0.0.tgz",
+      "integrity": "sha1-odmL+WDBUILYo/pp6DFQzMzDryY=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/define-lazy-prop": {
-      "version": "2.0.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
-      "integrity": "sha1-P3rkIRKbyqrJvHSQXJigAJ7J7n8=",
+      "version": "3.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha1-27Ga37dG1/xtc0oGty9KANAhJV8=",
       "license": "MIT",
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -3988,6 +3837,7 @@
       "version": "2.0.3",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/detect-libc/-/detect-libc-2.0.3.tgz",
       "integrity": "sha1-8M1QO0D5k5uJRpfRmtUIleMM9wA=",
+      "license": "Apache-2.0",
       "optional": true,
       "engines": {
         "node": ">=8"
@@ -4074,6 +3924,20 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha1-165mfh3INIL4tw/Q9u78UNow9Yo=",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/ecdsa-sig-formatter": {
       "version": "1.0.11",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
@@ -4105,9 +3969,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.811",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/electron-to-chromium/-/electron-to-chromium-1.4.811.tgz",
-      "integrity": "sha1-AxyLEB59CnzeHf2wYj29teGWVc0=",
+      "version": "1.5.103",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/electron-to-chromium/-/electron-to-chromium-1.5.103.tgz",
+      "integrity": "sha1-PQICW8FuluXts+0/+iU4oRrmgtw=",
       "dev": true,
       "license": "ISC"
     },
@@ -4142,9 +4006,9 @@
       }
     },
     "node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc=",
+      "version": "10.4.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/emoji-regex/-/emoji-regex-10.4.0.tgz",
+      "integrity": "sha1-A1U6/qgLOXV0nPyzb3dsomjkE9Q=",
       "dev": true,
       "license": "MIT"
     },
@@ -4158,6 +4022,7 @@
       "version": "2.0.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/encodeurl/-/encodeurl-2.0.0.tgz",
       "integrity": "sha1-e46omAd9fkCdOsRUdOo46vCFelg=",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -4186,13 +4051,10 @@
       }
     },
     "node_modules/es-define-property": {
-      "version": "1.0.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/es-define-property/-/es-define-property-1.0.0.tgz",
-      "integrity": "sha1-x/rvvf+LJpbPX0aSHt+3fMS6OEU=",
+      "version": "1.0.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha1-mD6y+aZyTpMD9hrd8BHHLgngsPo=",
       "license": "MIT",
-      "dependencies": {
-        "get-intrinsic": "^1.2.4"
-      },
       "engines": {
         "node": ">= 0.4"
       }
@@ -4206,6 +4068,34 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha1-HE8sSDcydZfOadLKGQp/3RcjOME=",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha1-8x274MGDsAptJutjJcgQwP0YvU0=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es6-promise": {
       "version": "4.2.8",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/es6-promise/-/es6-promise-4.2.8.tgz",
@@ -4213,9 +4103,9 @@
       "license": "MIT"
     },
     "node_modules/escalade": {
-      "version": "3.1.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/escalade/-/escalade-3.1.2.tgz",
-      "integrity": "sha1-VAdumrKepb89jx7WKs/7uIJy3yc=",
+      "version": "3.2.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha1-ARo/aYVroYnf+n3I/M6Z0qh5A+U=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4225,7 +4115,8 @@
     "node_modules/escape-html": {
       "version": "1.0.3",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
+      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -4240,21 +4131,21 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.17.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/eslint/-/eslint-9.17.0.tgz",
-      "integrity": "sha1-+qH6y13QQhcv3FIBBphLXCQhuww=",
+      "version": "9.21.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/eslint/-/eslint-9.21.0.tgz",
+      "integrity": "sha1-scnBb1FT/yGXkfYnuUq48R+BFZE=",
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.19.0",
-        "@eslint/core": "^0.9.0",
-        "@eslint/eslintrc": "^3.2.0",
-        "@eslint/js": "9.17.0",
-        "@eslint/plugin-kit": "^0.2.3",
+        "@eslint/config-array": "^0.19.2",
+        "@eslint/core": "^0.12.0",
+        "@eslint/eslintrc": "^3.3.0",
+        "@eslint/js": "9.21.0",
+        "@eslint/plugin-kit": "^0.2.7",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
-        "@humanwhocodes/retry": "^0.4.1",
+        "@humanwhocodes/retry": "^0.4.2",
         "@types/estree": "^1.0.6",
         "@types/json-schema": "^7.0.15",
         "ajv": "^6.12.4",
@@ -4309,9 +4200,9 @@
       }
     },
     "node_modules/eslint-plugin-jest": {
-      "version": "28.10.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/eslint-plugin-jest/-/eslint-plugin-jest-28.10.0.tgz",
-      "integrity": "sha1-SzW4q7D3z+aZv/jZBgJwot3XcOo=",
+      "version": "28.11.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/eslint-plugin-jest/-/eslint-plugin-jest-28.11.0.tgz",
+      "integrity": "sha1-JkHstEEZQbvds9fPio/xFj+7UQ4=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4351,35 +4242,6 @@
       }
     },
     "node_modules/eslint-visitor-keys": {
-      "version": "3.4.3",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-      "integrity": "sha1-DNcv6FUOPC6uFWqWpN3c0cisWAA=",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/eslint/node_modules/debug": {
-      "version": "4.3.5",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/debug/-/debug-4.3.5.tgz",
-      "integrity": "sha1-6DRE7Ouf7dSh2lbWca4kRqAabh4=",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/eslint/node_modules/eslint-visitor-keys": {
       "version": "4.2.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
       "integrity": "sha1-aHussq+IT83aim59ZcYG9GoUzUU=",
@@ -4391,10 +4253,27 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint/node_modules/debug": {
+      "version": "4.4.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha1-Kz8q6i/+t3ZHdGAmc3fchxD6uoo=",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/eslint/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
+      "version": "2.1.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI=",
       "license": "MIT"
     },
     "node_modules/espree": {
@@ -4407,18 +4286,6 @@
         "acorn-jsx": "^5.3.2",
         "eslint-visitor-keys": "^4.2.0"
       },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/espree/node_modules/eslint-visitor-keys": {
-      "version": "4.2.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
-      "integrity": "sha1-aHussq+IT83aim59ZcYG9GoUzUU=",
-      "license": "Apache-2.0",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -4441,9 +4308,9 @@
       }
     },
     "node_modules/esquery": {
-      "version": "1.5.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/esquery/-/esquery-1.5.0.tgz",
-      "integrity": "sha1-bOF3ON6Fd2lO3XNhxXGCrIyw2ws=",
+      "version": "1.6.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/esquery/-/esquery-1.6.0.tgz",
+      "integrity": "sha1-kUGSNPgE2FKoLc7sPhbNwiz52uc=",
       "license": "BSD-3-Clause",
       "dependencies": {
         "estraverse": "^5.1.0"
@@ -4486,6 +4353,7 @@
       "version": "1.8.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -4689,30 +4557,27 @@
       "license": "MIT"
     },
     "node_modules/fast-xml-parser": {
-      "version": "4.4.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
-      "integrity": "sha1-htvz8Y7fhzkyZEe8qsMbSuf2UU8=",
+      "version": "4.5.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/fast-xml-parser/-/fast-xml-parser-4.5.3.tgz",
+      "integrity": "sha1-xU1rNaoPI9wepgtsiENAwAbcbvs=",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/NaturalIntelligence"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/naturalintelligence"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "strnum": "^1.0.5"
+        "strnum": "^1.1.1"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
       }
     },
     "node_modules/fastq": {
-      "version": "1.18.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/fastq/-/fastq-1.18.0.tgz",
-      "integrity": "sha1-1jHX4l+v/qgYh/5eqMkBDhs2/uA=",
+      "version": "1.19.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/fastq/-/fastq-1.19.0.tgz",
+      "integrity": "sha1-qCxrfCu05Edm2GXweZd4X+z9y4k=",
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
@@ -4793,6 +4658,7 @@
       "version": "1.3.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/finalhandler/-/finalhandler-1.3.1.tgz",
       "integrity": "sha1-DFdfHR0yTd0do1rX7OPffRkIgBk=",
+      "license": "MIT",
       "dependencies": {
         "debug": "2.6.9",
         "encodeurl": "~2.0.0",
@@ -4836,9 +4702,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/flatted/-/flatted-3.3.2.tgz",
-      "integrity": "sha1-rboUSKmEG+xytCxTLqI9u+3vGic=",
+      "version": "3.3.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/flatted/-/flatted-3.3.3.tgz",
+      "integrity": "sha1-Z8j62VRUp8er6/dLt47nSkQCM1g=",
       "license": "ISC"
     },
     "node_modules/fn.name": {
@@ -4848,13 +4714,15 @@
       "license": "MIT"
     },
     "node_modules/form-data": {
-      "version": "4.0.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha1-k5Gdrq82HuUpWEubMWZNwSyfpFI=",
+      "version": "4.0.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/form-data/-/form-data-4.0.2.tgz",
+      "integrity": "sha1-Ncq73TDDznPessQtPI0+2cpReUw=",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
         "mime-types": "^2.1.12"
       },
       "engines": {
@@ -4958,16 +4826,21 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.2.4",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
-      "integrity": "sha1-44X1pLUifUScPqu60FSU7wq76t0=",
+      "version": "1.3.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha1-dD8OO2lkqTpUke0b/6rgVNf5jQE=",
       "license": "MIT",
       "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
         "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
         "function-bind": "^1.1.2",
-        "has-proto": "^1.0.1",
-        "has-symbols": "^1.0.3",
-        "hasown": "^2.0.0"
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4984,6 +4857,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha1-FQs/J0OGnvPoUewMSdFbHRTQDuE=",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-stream": {
@@ -5032,9 +4918,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "15.14.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/globals/-/globals-15.14.0.tgz",
-      "integrity": "sha1-uP06iUH/O0048zGdQzthu7SC5z8=",
+      "version": "15.15.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/globals/-/globals-15.15.0.tgz",
+      "integrity": "sha1-fEdhKZ1BwysHVxWkzh7eeJf/cqg=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5045,12 +4931,12 @@
       }
     },
     "node_modules/gopd": {
-      "version": "1.0.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/gopd/-/gopd-1.0.1.tgz",
-      "integrity": "sha1-Kf923mnax0ibfAkYpXiOVkd8Myw=",
+      "version": "1.2.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha1-ifVrghe9vIgCvSmd9tfxCB1+UaE=",
       "license": "MIT",
-      "dependencies": {
-        "get-intrinsic": "^1.1.3"
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -5078,22 +4964,10 @@
         "node": ">=8"
       }
     },
-    "node_modules/has-property-descriptors": {
-      "version": "1.0.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
-      "integrity": "sha1-lj7X0HHce/XwhMW/vg0bYiJYaFQ=",
-      "license": "MIT",
-      "dependencies": {
-        "es-define-property": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-proto": {
-      "version": "1.0.3",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/has-proto/-/has-proto-1.0.3.tgz",
-      "integrity": "sha1-sx3f6bDm6ZFFNqarKGQm0CFPd/0=",
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha1-/JxqeDoISVHQuXH+EBjegTcHozg=",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5102,11 +4976,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/has-symbols": {
-      "version": "1.0.3",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/has-symbols/-/has-symbols-1.0.3.tgz",
-      "integrity": "sha1-u3ssQ0klHc6HsSX3vfh0qnyLOfg=",
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha1-LNxC1AvvLltO6rfAGnPFTOerWrw=",
+      "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -5127,9 +5005,9 @@
       }
     },
     "node_modules/helmet": {
-      "version": "7.1.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/helmet/-/helmet-7.1.0.tgz",
-      "integrity": "sha1-KHJ54A+KN2PV3MuvHl7jm4w3hMo=",
+      "version": "7.2.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/helmet/-/helmet-7.2.0.tgz",
+      "integrity": "sha1-iy3MQltKRsiPaVNIG0BFPL5msWc=",
       "license": "MIT",
       "engines": {
         "node": ">=16.0.0"
@@ -5169,26 +5047,25 @@
       }
     },
     "node_modules/http-proxy-agent": {
-      "version": "5.0.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
-      "integrity": "sha1-USmAAgNSDUNPFCvHj/PBcIAPK0M=",
+      "version": "7.0.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha1-mosfJGhmwChQlIZYX2K48sGMJw4=",
       "license": "MIT",
       "dependencies": {
-        "@tootallnate/once": "2",
-        "agent-base": "6",
-        "debug": "4"
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 14"
       }
     },
     "node_modules/http-proxy-agent/node_modules/debug": {
-      "version": "4.3.5",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/debug/-/debug-4.3.5.tgz",
-      "integrity": "sha1-6DRE7Ouf7dSh2lbWca4kRqAabh4=",
+      "version": "4.4.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha1-Kz8q6i/+t3ZHdGAmc3fchxD6uoo=",
       "license": "MIT",
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -5200,31 +5077,31 @@
       }
     },
     "node_modules/http-proxy-agent/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
+      "version": "2.1.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI=",
       "license": "MIT"
     },
     "node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha1-xZ7yJKBP6LdU89sAY6Jeow0ABdY=",
+      "version": "7.0.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha1-2o3+rH2hMLBcK6S1nJts1mYRprk=",
       "license": "MIT",
       "dependencies": {
-        "agent-base": "6",
+        "agent-base": "^7.1.2",
         "debug": "4"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 14"
       }
     },
     "node_modules/https-proxy-agent/node_modules/debug": {
-      "version": "4.3.5",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/debug/-/debug-4.3.5.tgz",
-      "integrity": "sha1-6DRE7Ouf7dSh2lbWca4kRqAabh4=",
+      "version": "4.4.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha1-Kz8q6i/+t3ZHdGAmc3fchxD6uoo=",
       "license": "MIT",
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -5236,9 +5113,9 @@
       }
     },
     "node_modules/https-proxy-agent/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
+      "version": "2.1.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI=",
       "license": "MIT"
     },
     "node_modules/human-signals": {
@@ -5325,9 +5202,9 @@
       "license": "ISC"
     },
     "node_modules/import-fresh": {
-      "version": "3.3.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/import-fresh/-/import-fresh-3.3.0.tgz",
-      "integrity": "sha1-NxYsJfy566oublPVtNiM4X2eDCs=",
+      "version": "3.3.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha1-nOy1ZQPAraHydB271lRuSxO1fM8=",
       "license": "MIT",
       "dependencies": {
         "parent-module": "^1.0.0",
@@ -5341,21 +5218,21 @@
       }
     },
     "node_modules/import-in-the-middle": {
-      "version": "1.4.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/import-in-the-middle/-/import-in-the-middle-1.4.2.tgz",
-      "integrity": "sha1-KiZmduNJXnLAS7ql7BR1a6FoORs=",
+      "version": "1.13.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/import-in-the-middle/-/import-in-the-middle-1.13.0.tgz",
+      "integrity": "sha1-5ZJYPD9T/ynGB5wK8x/qtZKsayo=",
       "license": "Apache-2.0",
       "dependencies": {
-        "acorn": "^8.8.2",
-        "acorn-import-assertions": "^1.9.0",
+        "acorn": "^8.14.0",
+        "acorn-import-attributes": "^1.9.5",
         "cjs-module-lexer": "^1.2.2",
         "module-details-from-path": "^1.0.3"
       }
     },
     "node_modules/import-local": {
-      "version": "3.1.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/import-local/-/import-local-3.1.0.tgz",
-      "integrity": "sha1-tEed+KX9RPbNziQHBnVnYGPJXLQ=",
+      "version": "3.2.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/import-local/-/import-local-3.2.0.tgz",
+      "integrity": "sha1-w9XHRXmMAqb4uJdyarpRABhu4mA=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5407,9 +5284,9 @@
       "license": "ISC"
     },
     "node_modules/ioredis": {
-      "version": "5.4.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ioredis/-/ioredis-5.4.1.tgz",
-      "integrity": "sha1-HFa3C3WfAUZZE4hzde2AkTQpb0A=",
+      "version": "5.5.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ioredis/-/ioredis-5.5.0.tgz",
+      "integrity": "sha1-/yMy4SXKKsjhVHLd0U7N/6ZISio=",
       "license": "MIT",
       "dependencies": {
         "@ioredis/commands": "^1.1.1",
@@ -5431,12 +5308,12 @@
       }
     },
     "node_modules/ioredis/node_modules/debug": {
-      "version": "4.3.5",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/debug/-/debug-4.3.5.tgz",
-      "integrity": "sha1-6DRE7Ouf7dSh2lbWca4kRqAabh4=",
+      "version": "4.4.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha1-Kz8q6i/+t3ZHdGAmc3fchxD6uoo=",
       "license": "MIT",
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -5448,9 +5325,9 @@
       }
     },
     "node_modules/ioredis/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
+      "version": "2.1.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI=",
       "license": "MIT"
     },
     "node_modules/ipaddr.js": {
@@ -5506,9 +5383,9 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.14.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-core-module/-/is-core-module-2.14.0.tgz",
-      "integrity": "sha1-Q7jvn0amoIiI22ex/9Tsnj39WdE=",
+      "version": "2.16.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha1-KpiAGoSfQ+Kt1kT7trxiKbGaTvQ=",
       "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.2"
@@ -5521,15 +5398,15 @@
       }
     },
     "node_modules/is-docker": {
-      "version": "2.2.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-docker/-/is-docker-2.2.1.tgz",
-      "integrity": "sha1-M+6r4jz+hvFL3kQIoCwM+4U6zao=",
+      "version": "3.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha1-kAk6oxBid9inelkQ265xdH4VogA=",
       "license": "MIT",
       "bin": {
         "is-docker": "cli.js"
       },
       "engines": {
-        "node": ">=8"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -5545,13 +5422,16 @@
       }
     },
     "node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0=",
+      "version": "4.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz",
+      "integrity": "sha1-+uMWfHKedGP4RhzlErCApJJoqog=",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-generator-fn": {
@@ -5574,6 +5454,24 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha1-6B+6aZZi6zHb2vJnZqYdSBRxfqQ=",
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-number": {
@@ -5608,15 +5506,18 @@
       }
     },
     "node_modules/is-wsl": {
-      "version": "2.2.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-wsl/-/is-wsl-2.2.0.tgz",
-      "integrity": "sha1-dKTHbnfKn9P5MvKQwX6jJs0VcnE=",
+      "version": "3.1.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-wsl/-/is-wsl-3.1.0.tgz",
+      "integrity": "sha1-4cZX45wQCQr8vt7GFyD2uSTDy9I=",
       "license": "MIT",
       "dependencies": {
-        "is-docker": "^2.0.0"
+        "is-inside-container": "^1.0.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/isexe": {
@@ -5636,9 +5537,9 @@
       }
     },
     "node_modules/istanbul-lib-instrument": {
-      "version": "6.0.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.2.tgz",
-      "integrity": "sha1-kWVZNs9zgOTkczgwgeOEeLaZk7E=",
+      "version": "6.0.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
+      "integrity": "sha1-+hVAHfbBWHS8shBfdzMl14xmZ2U=",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -5683,13 +5584,13 @@
       }
     },
     "node_modules/istanbul-lib-source-maps/node_modules/debug": {
-      "version": "4.3.5",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/debug/-/debug-4.3.5.tgz",
-      "integrity": "sha1-6DRE7Ouf7dSh2lbWca4kRqAabh4=",
+      "version": "4.4.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha1-Kz8q6i/+t3ZHdGAmc3fchxD6uoo=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -5701,9 +5602,9 @@
       }
     },
     "node_modules/istanbul-lib-source-maps/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
+      "version": "2.1.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI=",
       "dev": true,
       "license": "MIT"
     },
@@ -5722,9 +5623,9 @@
       }
     },
     "node_modules/jake": {
-      "version": "10.9.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jake/-/jake-10.9.1.tgz",
-      "integrity": "sha1-jclrf8xByxmqUCr1BtpOHVb15is=",
+      "version": "10.9.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jake/-/jake-10.9.2.tgz",
+      "integrity": "sha1-auSH5qaa/sOl4WdiiZa1nzWuK38=",
       "license": "Apache-2.0",
       "dependencies": {
         "async": "^3.2.3",
@@ -6007,19 +5908,6 @@
       },
       "engines": {
         "node": ">=10.12.0"
-      }
-    },
-    "node_modules/jest-junit/node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha1-PrXtYmInVteaXw4qIh3+utdcL34=",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/jest-junit/node_modules/uuid": {
@@ -6387,16 +6275,16 @@
       }
     },
     "node_modules/jsesc": {
-      "version": "2.5.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jsesc/-/jsesc-2.5.2.tgz",
-      "integrity": "sha1-gFZNLkg9rPbo7yCWUKZ98/DCg6Q=",
+      "version": "3.1.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha1-dNM1ojT2ftGZB/2t+sfM+dQJgl0=",
       "dev": true,
       "license": "MIT",
       "bin": {
         "jsesc": "bin/jsesc"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=6"
       }
     },
     "node_modules/json-buffer": {
@@ -6564,22 +6452,22 @@
       "license": "MIT"
     },
     "node_modules/lint-staged": {
-      "version": "15.3.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/lint-staged/-/lint-staged-15.3.0.tgz",
-      "integrity": "sha1-MqCz8vK4gllQvTufsJPgRTU736M=",
+      "version": "15.4.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/lint-staged/-/lint-staged-15.4.3.tgz",
+      "integrity": "sha1-5zWHzIV/WAyZ+Qer7+msjY1edME=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "chalk": "~5.4.1",
-        "commander": "~12.1.0",
-        "debug": "~4.4.0",
-        "execa": "~8.0.1",
-        "lilconfig": "~3.1.3",
-        "listr2": "~8.2.5",
-        "micromatch": "~4.0.8",
-        "pidtree": "~0.6.0",
-        "string-argv": "~0.3.2",
-        "yaml": "~2.6.1"
+        "chalk": "^5.4.1",
+        "commander": "^13.1.0",
+        "debug": "^4.4.0",
+        "execa": "^8.0.1",
+        "lilconfig": "^3.1.3",
+        "listr2": "^8.2.5",
+        "micromatch": "^4.0.8",
+        "pidtree": "^0.6.0",
+        "string-argv": "^0.3.2",
+        "yaml": "^2.7.0"
       },
       "bin": {
         "lint-staged": "bin/lint-staged.js"
@@ -6791,91 +6679,6 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/listr2/node_modules/ansi-regex": {
-      "version": "6.1.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ansi-regex/-/ansi-regex-6.1.0.tgz",
-      "integrity": "sha1-lexAnGlhnWyxuLNPFLZg7yjr1lQ=",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/listr2/node_modules/ansi-styles": {
-      "version": "6.2.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ansi-styles/-/ansi-styles-6.2.1.tgz",
-      "integrity": "sha1-DmIyDPmcIa//OzASGSVGqsv7BcU=",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/listr2/node_modules/emoji-regex": {
-      "version": "10.4.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/emoji-regex/-/emoji-regex-10.4.0.tgz",
-      "integrity": "sha1-A1U6/qgLOXV0nPyzb3dsomjkE9Q=",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/listr2/node_modules/string-width": {
-      "version": "7.2.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/string-width/-/string-width-7.2.0.tgz",
-      "integrity": "sha1-tbuOIWXOJ11NQ0dt0nAK2Qkdttw=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^10.3.0",
-        "get-east-asian-width": "^1.0.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/listr2/node_modules/strip-ansi": {
-      "version": "7.1.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/strip-ansi/-/strip-ansi-7.1.0.tgz",
-      "integrity": "sha1-1bZWjKaJ2FYTcLBwdoXSJDT6/0U=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
-    "node_modules/listr2/node_modules/wrap-ansi": {
-      "version": "9.0.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/wrap-ansi/-/wrap-ansi-9.0.0.tgz",
-      "integrity": "sha1-Gj3Itw2F7rg5jd+x5KAs0Ybliz4=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.2.1",
-        "string-width": "^7.0.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/locate-path/-/locate-path-6.0.0.tgz",
@@ -7025,13 +6828,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/log-update/node_modules/emoji-regex": {
-      "version": "10.4.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/emoji-regex/-/emoji-regex-10.4.0.tgz",
-      "integrity": "sha1-A1U6/qgLOXV0nPyzb3dsomjkE9Q=",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/log-update/node_modules/is-fullwidth-code-point": {
       "version": "5.0.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-fullwidth-code-point/-/is-fullwidth-code-point-5.0.0.tgz",
@@ -7065,24 +6861,6 @@
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
       }
     },
-    "node_modules/log-update/node_modules/string-width": {
-      "version": "7.2.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/string-width/-/string-width-7.2.0.tgz",
-      "integrity": "sha1-tbuOIWXOJ11NQ0dt0nAK2Qkdttw=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^10.3.0",
-        "get-east-asian-width": "^1.0.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/log-update/node_modules/strip-ansi": {
       "version": "7.1.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/strip-ansi/-/strip-ansi-7.1.0.tgz",
@@ -7099,28 +6877,10 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
-    "node_modules/log-update/node_modules/wrap-ansi": {
-      "version": "9.0.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/wrap-ansi/-/wrap-ansi-9.0.0.tgz",
-      "integrity": "sha1-Gj3Itw2F7rg5jd+x5KAs0Ybliz4=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.2.1",
-        "string-width": "^7.0.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
     "node_modules/logform": {
-      "version": "2.6.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/logform/-/logform-2.6.0.tgz",
-      "integrity": "sha1-jIKpg/Bdbq6y11497K56dosr+bU=",
+      "version": "2.7.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/logform/-/logform-2.7.0.tgz",
+      "integrity": "sha1-z8qXUo7ykPLhJaCDloBQArLQYNE=",
       "license": "MIT",
       "dependencies": {
         "@colors/colors": "1.6.0",
@@ -7141,8 +6901,8 @@
       "license": "MIT"
     },
     "node_modules/login.dfe.api.auth": {
-      "version": "2.3.0",
-      "resolved": "git+ssh://git@github.com/DFE-Digital/login.dfe.api.auth.git#54aae554a66b4517555d5de6304dd79eba6a116c",
+      "version": "2.3.3",
+      "resolved": "git+ssh://git@github.com/DFE-Digital/login.dfe.api.auth.git#31c1db64742b683995d6fb2091725f4937739abb",
       "license": "MIT",
       "dependencies": {
         "jsonwebtoken": "^9.0.2",
@@ -7151,8 +6911,8 @@
       }
     },
     "node_modules/login.dfe.async-retry": {
-      "version": "2.0.2",
-      "resolved": "git+ssh://git@github.com/DFE-Digital/login.dfe.async-retry.git#1d5ec0e2d24520550226d777eb6014c697123a3b",
+      "version": "2.0.3",
+      "resolved": "git+ssh://git@github.com/DFE-Digital/login.dfe.async-retry.git#72c42369276361f6cdeaabc331100f50b4a10dbf",
       "license": "MIT",
       "dependencies": {
         "retry": "^0.13.1"
@@ -7170,30 +6930,20 @@
         "winston-transport": "^4.4.0"
       }
     },
-    "node_modules/login.dfe.audit.winston-sequelize-transport": {
-      "version": "3.2.1",
-      "resolved": "git+ssh://git@github.com/DFE-Digital/login.dfe.audit.winston-sequelize-transport.git#7937950afd8d17f450e0313c0ace4b5d06eb34cd",
+    "node_modules/login.dfe.audit.transporter/node_modules/@types/node": {
+      "version": "20.17.19",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/node/-/node-20.17.19.tgz",
+      "integrity": "sha1-DyhpVVcZvvJmym4YJ/zcqQPBppc=",
       "license": "MIT",
       "dependencies": {
-        "lodash": "^4.17.15",
-        "sequelize": "^6.3.3",
-        "tedious": "^18.2.1",
-        "uuid": "^9.0.0",
-        "winston-transport": "^4.5.0"
+        "undici-types": "~6.19.2"
       }
     },
-    "node_modules/login.dfe.audit.winston-sequelize-transport/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha1-4YjUyIU8xyIiA5LEJM1jfzIpPzA=",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
+    "node_modules/login.dfe.audit.transporter/node_modules/undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha1-NREcnRQ3q4OnzcCrri8m2I7aCgI=",
+      "license": "MIT"
     },
     "node_modules/login.dfe.config.schema.common": {
       "version": "1.9.4",
@@ -7343,6 +7093,18 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/login.dfe.dao/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha1-DNcv6FUOPC6uFWqWpN3c0cisWAA=",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/login.dfe.dao/node_modules/espree": {
       "version": "9.6.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/espree/-/espree-9.6.1.tgz",
@@ -7407,6 +7169,33 @@
       "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI=",
       "license": "MIT"
     },
+    "node_modules/login.dfe.dao/node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha1-8aVAK6YiCtUswSgrrBrjqkn9Bho=",
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/login.dfe.dao/node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha1-G/IH9LKPkVg2ZstfvTJ4hzAc1fQ=",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/login.dfe.dao/node_modules/uuid": {
       "version": "9.0.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/uuid/-/uuid-9.0.1.tgz",
@@ -7443,13 +7232,14 @@
     "node_modules/login.dfe.jobs-client": {
       "version": "6.1.0",
       "resolved": "git+ssh://git@github.com/DFE-Digital/login.dfe.jobs-client.git#0c271c49c7c91cdcea52acc148c27aaa152c0744",
+      "license": "MIT",
       "dependencies": {
         "bullmq": "^5.29.0"
       }
     },
     "node_modules/login.dfe.jwt-strategies": {
-      "version": "4.1.0",
-      "resolved": "git+ssh://git@github.com/DFE-Digital/login.dfe.jwt-strategies.git#33231d6cdf373cc3c2b78b31762cbcc6143b907d",
+      "version": "4.1.1",
+      "resolved": "git+ssh://git@github.com/DFE-Digital/login.dfe.jwt-strategies.git#e73c81f47d8352b2609c2eeab691e5c68c8f6727",
       "license": "MIT",
       "dependencies": {
         "@azure/msal-node": "^2.6.4"
@@ -7465,8 +7255,8 @@
       }
     },
     "node_modules/login.dfe.winston-appinsights": {
-      "version": "5.0.1",
-      "resolved": "git+ssh://git@github.com/DFE-Digital/login.dfe.winston-appinsights.git#fe50b019f8bd9b065808601ef85d95d431b075ba",
+      "version": "5.0.3",
+      "resolved": "git+ssh://git@github.com/DFE-Digital/login.dfe.winston-appinsights.git#e38aff47f0db953fb93f82efb3287cd66ac08799",
       "license": "MIT",
       "dependencies": {
         "applicationinsights": "^2.0.0",
@@ -7477,9 +7267,9 @@
       }
     },
     "node_modules/long": {
-      "version": "5.2.3",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/long/-/long-5.2.3.tgz",
-      "integrity": "sha1-o7qX84d88dd47MvLBIUl67d0meE=",
+      "version": "5.3.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/long/-/long-5.3.1.tgz",
+      "integrity": "sha1-nUIi0yE/OKXsgJZ0g04PCrIavpY=",
       "license": "Apache-2.0"
     },
     "node_modules/lru-cache": {
@@ -7496,6 +7286,7 @@
       "version": "3.5.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/luxon/-/luxon-3.5.0.tgz",
       "integrity": "sha1-a29lxc0dYdH9Gdvwfuh6UL9LjiA=",
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       }
@@ -7526,6 +7317,15 @@
         "tmpl": "1.0.5"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha1-oN10voHiqlwvJ+Zc4oNgXuTit/k=",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/media-typer": {
       "version": "0.3.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/media-typer/-/media-typer-0.3.0.tgz",
@@ -7539,6 +7339,7 @@
       "version": "1.0.3",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
       "integrity": "sha1-2AMZpl88eTU1Hlz9rI+TGFBNvtU=",
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
@@ -7574,6 +7375,7 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha1-1m+hjzpHB2eJMgubGvMr2G2fogI=",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
         "picomatch": "^2.3.1"
@@ -7661,16 +7463,16 @@
       }
     },
     "node_modules/mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha1-fe8D0kMtyuS6HWEURcSDlgYiVfY=",
+      "version": "1.0.4",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha1-PrXtYmInVteaXw4qIh3+utdcL34=",
+      "dev": true,
       "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "minimist": "^1.2.6"
-      },
       "bin": {
         "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/module-details-from-path": {
@@ -7689,9 +7491,9 @@
       }
     },
     "node_modules/moment-timezone": {
-      "version": "0.5.45",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/moment-timezone/-/moment-timezone-0.5.45.tgz",
-      "integrity": "sha1-y2hazVa6wQ5p2TxTY2brZaprz1w=",
+      "version": "0.5.47",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/moment-timezone/-/moment-timezone-0.5.47.tgz",
+      "integrity": "sha1-1NGiG3g3LZFNbWmuKFRUcypCl0k=",
       "license": "MIT",
       "dependencies": {
         "moment": "^2.29.4"
@@ -7720,6 +7522,7 @@
       "version": "1.11.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/msgpackr/-/msgpackr-1.11.2.tgz",
       "integrity": "sha1-RGO399aPLiSGXDlWZJc1Yq0kRz0=",
+      "license": "MIT",
       "optionalDependencies": {
         "msgpackr-extract": "^3.0.2"
       }
@@ -7729,6 +7532,7 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/msgpackr-extract/-/msgpackr-extract-3.0.3.tgz",
       "integrity": "sha1-6dhwI945znFIcvnpUE48GZbWEBI=",
       "hasInstallScript": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "node-gyp-build-optional-packages": "5.2.2"
@@ -7760,40 +7564,23 @@
         "node": ">=0.8.0"
       }
     },
-    "node_modules/mv/node_modules/glob": {
-      "version": "6.0.4",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/glob/-/glob-6.0.4.tgz",
-      "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
-      "license": "ISC",
+    "node_modules/mv/node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha1-fe8D0kMtyuS6HWEURcSDlgYiVfY=",
+      "license": "MIT",
       "optional": true,
       "dependencies": {
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "2 || 3",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/mv/node_modules/rimraf": {
-      "version": "2.4.5",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/rimraf/-/rimraf-2.4.5.tgz",
-      "integrity": "sha1-7nEM5dk6j9uFb7Xqj/Di11k0sto=",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "glob": "^6.0.1"
+        "minimist": "^1.2.6"
       },
       "bin": {
-        "rimraf": "bin.js"
+        "mkdirp": "bin/cmd.js"
       }
     },
     "node_modules/nan": {
-      "version": "2.20.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/nan/-/nan-2.20.0.tgz",
-      "integrity": "sha1-CMXqgT3VTtFuW9ZQW/Qq9PeDjKM=",
+      "version": "2.22.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/nan/-/nan-2.22.1.tgz",
+      "integrity": "sha1-J6rLukY7Be13UdPAA19zyxr8+3U=",
       "license": "MIT",
       "optional": true
     },
@@ -7841,7 +7628,8 @@
     "node_modules/node-abort-controller": {
       "version": "3.1.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/node-abort-controller/-/node-abort-controller-3.1.1.tgz",
-      "integrity": "sha1-qUN36WSpo3rDl22EjLXHZYM7hUg="
+      "integrity": "sha1-qUN36WSpo3rDl22EjLXHZYM7hUg=",
+      "license": "MIT"
     },
     "node_modules/node-forge": {
       "version": "1.3.1",
@@ -7856,6 +7644,7 @@
       "version": "5.2.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.2.2.tgz",
       "integrity": "sha1-Ui9QwtUxNNfzp2zXJV3kq2yWo6Q=",
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "detect-libc": "^2.0.1"
@@ -7904,14 +7693,12 @@
       }
     },
     "node_modules/node-mocks-http": {
-      "version": "1.15.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/node-mocks-http/-/node-mocks-http-1.15.0.tgz",
-      "integrity": "sha1-/nux76SrOVc59Al7RPdFRAMmobM=",
+      "version": "1.16.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/node-mocks-http/-/node-mocks-http-1.16.2.tgz",
+      "integrity": "sha1-Y+TJX5WPetxx1pucg5spy75gJz0=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/express": "^4.17.21",
-        "@types/node": "^20.10.6",
         "accepts": "^1.3.7",
         "content-disposition": "^0.5.3",
         "depd": "^1.1.0",
@@ -7925,6 +7712,18 @@
       },
       "engines": {
         "node": ">=14"
+      },
+      "peerDependencies": {
+        "@types/express": "^4.17.21 || ^5.0.0",
+        "@types/node": "*"
+      },
+      "peerDependenciesMeta": {
+        "@types/express": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/node-mocks-http/node_modules/depd": {
@@ -7938,16 +7737,16 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.14",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/node-releases/-/node-releases-2.0.14.tgz",
-      "integrity": "sha1-L/sFO864sr6Elezhq2zmAMRGGws=",
+      "version": "2.0.19",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/node-releases/-/node-releases-2.0.19.tgz",
+      "integrity": "sha1-nkRaUpUJUexNF32EOvNwtBHK8xQ=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/nodemon": {
-      "version": "3.1.4",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/nodemon/-/nodemon-3.1.4.tgz",
-      "integrity": "sha1-w03NjrRqBXI8zeYMvdJa3cyHJeQ=",
+      "version": "3.1.9",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/nodemon/-/nodemon-3.1.9.tgz",
+      "integrity": "sha1-31As3DsSDhw8DG5BUjSQGe+nOHs=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7974,13 +7773,13 @@
       }
     },
     "node_modules/nodemon/node_modules/debug": {
-      "version": "4.3.5",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/debug/-/debug-4.3.5.tgz",
-      "integrity": "sha1-6DRE7Ouf7dSh2lbWca4kRqAabh4=",
+      "version": "4.4.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha1-Kz8q6i/+t3ZHdGAmc3fchxD6uoo=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -8002,9 +7801,9 @@
       }
     },
     "node_modules/nodemon/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
+      "version": "2.1.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI=",
       "dev": true,
       "license": "MIT"
     },
@@ -8051,9 +7850,9 @@
       "license": "MIT"
     },
     "node_modules/object-inspect": {
-      "version": "1.13.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/object-inspect/-/object-inspect-1.13.2.tgz",
-      "integrity": "sha1-3qAIhGf7mR5nr0BYFHokgkowQ/8=",
+      "version": "1.13.4",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha1-g3UmXiG8IND6WCwi4bE0hdbgAhM=",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -8109,17 +7908,18 @@
       }
     },
     "node_modules/open": {
-      "version": "8.4.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/open/-/open-8.4.2.tgz",
-      "integrity": "sha1-W1/+Ko95Pc0qrXPlUMuHtZywhPk=",
+      "version": "10.1.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/open/-/open-10.1.0.tgz",
+      "integrity": "sha1-p3lebl1Rmr5ChtmTe7JLURIlmOE=",
       "license": "MIT",
       "dependencies": {
-        "define-lazy-prop": "^2.0.0",
-        "is-docker": "^2.1.1",
-        "is-wsl": "^2.2.0"
+        "default-browser": "^5.2.1",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "is-wsl": "^3.1.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -8268,6 +8068,54 @@
         "node": ">= 8.0.0"
       }
     },
+    "node_modules/passport-azure-ad/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha1-Sf/1hXfP7j83F2/qtMIuAPhtf3c=",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/passport-azure-ad/node_modules/debug": {
+      "version": "4.4.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha1-Kz8q6i/+t3ZHdGAmc3fchxD6uoo=",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/passport-azure-ad/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha1-xZ7yJKBP6LdU89sAY6Jeow0ABdY=",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/passport-azure-ad/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI=",
+      "license": "MIT"
+    },
     "node_modules/passport-strategy": {
       "version": "1.0.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/passport-strategy/-/passport-strategy-1.0.0.tgz",
@@ -8321,14 +8169,14 @@
       "integrity": "sha1-HUCLP9t2kjuVQ9lvtMnf1TXZy10="
     },
     "node_modules/pg": {
-      "version": "8.12.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/pg/-/pg-8.12.0.tgz",
-      "integrity": "sha1-k0FyTbVxAiSQtleQj2Wu6NuR33k=",
+      "version": "8.13.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/pg/-/pg-8.13.3.tgz",
+      "integrity": "sha1-Gc0CHR+enSbYYLgM1FDxCahlJzg=",
       "license": "MIT",
       "dependencies": {
-        "pg-connection-string": "^2.6.4",
-        "pg-pool": "^3.6.2",
-        "pg-protocol": "^1.6.1",
+        "pg-connection-string": "^2.7.0",
+        "pg-pool": "^3.7.1",
+        "pg-protocol": "^1.7.1",
         "pg-types": "^2.1.0",
         "pgpass": "1.x"
       },
@@ -8355,9 +8203,9 @@
       "optional": true
     },
     "node_modules/pg-connection-string": {
-      "version": "2.6.4",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/pg-connection-string/-/pg-connection-string-2.6.4.tgz",
-      "integrity": "sha1-9UOGKt+kn6ThS8ioiS0qhNdUJG0=",
+      "version": "2.7.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/pg-connection-string/-/pg-connection-string-2.7.0.tgz",
+      "integrity": "sha1-8dNInkJ8YuzgItupjVJi78sWizc=",
       "license": "MIT"
     },
     "node_modules/pg-int8": {
@@ -8370,18 +8218,18 @@
       }
     },
     "node_modules/pg-pool": {
-      "version": "3.6.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/pg-pool/-/pg-pool-3.6.2.tgz",
-      "integrity": "sha1-OlkjcLiuPwKnyBMNJFvAL6LF8/I=",
+      "version": "3.7.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/pg-pool/-/pg-pool-3.7.1.tgz",
+      "integrity": "sha1-0ar2GGGNj4eKzxhehghJKLjNWzw=",
       "license": "MIT",
       "peerDependencies": {
         "pg": ">=8.0"
       }
     },
     "node_modules/pg-protocol": {
-      "version": "1.6.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/pg-protocol/-/pg-protocol-1.6.1.tgz",
-      "integrity": "sha1-ITM+bYOwH6rr/nozp61r/Z7TjLM=",
+      "version": "1.7.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/pg-protocol/-/pg-protocol-1.7.1.tgz",
+      "integrity": "sha1-qtYab5J7Ueidz3IUCLdsDlNtQ9w=",
       "license": "MIT"
     },
     "node_modules/pg-types": {
@@ -8410,9 +8258,9 @@
       }
     },
     "node_modules/picocolors": {
-      "version": "1.0.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/picocolors/-/picocolors-1.0.1.tgz",
-      "integrity": "sha1-qK1Xm1cZUvDl0liS3lRFvP4lqqE=",
+      "version": "1.1.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha1-PTIa8+q5ObCDyPkpodEs2oHCa2s=",
       "dev": true,
       "license": "ISC"
     },
@@ -8570,9 +8418,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.4.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/prettier/-/prettier-3.4.2.tgz",
-      "integrity": "sha1-pc4ftSKliL8reMpExub+WqWisT8=",
+      "version": "3.5.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/prettier/-/prettier-3.5.2.tgz",
+      "integrity": "sha1-0GbGBTIA2gI0v4+h70UWir7YuRQ=",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -8686,6 +8534,7 @@
       "version": "6.13.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/qs/-/qs-6.13.0.tgz",
       "integrity": "sha1-bKO9WEOffiRWVXmJl3h7DYilGQY=",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.0.6"
       },
@@ -8757,9 +8606,9 @@
       "license": "MIT"
     },
     "node_modules/readable-stream": {
-      "version": "4.5.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/readable-stream/-/readable-stream-4.5.2.tgz",
-      "integrity": "sha1-nn/ExFCZuu7ZNL/265e6bPJyngk=",
+      "version": "4.7.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha1-ztvYoRRsE9//jasUBoAo1YwVrJE=",
       "license": "MIT",
       "dependencies": {
         "abort-controller": "^3.0.0",
@@ -8817,26 +8666,26 @@
       }
     },
     "node_modules/require-in-the-middle": {
-      "version": "7.3.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/require-in-the-middle/-/require-in-the-middle-7.3.0.tgz",
-      "integrity": "sha1-zmShCDZH3AezJzs0g1fvrIqZRck=",
+      "version": "7.5.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/require-in-the-middle/-/require-in-the-middle-7.5.2.tgz",
+      "integrity": "sha1-3CWxSK/61C5XDPDkG6MNwA8XA+w=",
       "license": "MIT",
       "dependencies": {
-        "debug": "^4.1.1",
+        "debug": "^4.3.5",
         "module-details-from-path": "^1.0.3",
-        "resolve": "^1.22.1"
+        "resolve": "^1.22.8"
       },
       "engines": {
         "node": ">=8.6.0"
       }
     },
     "node_modules/require-in-the-middle/node_modules/debug": {
-      "version": "4.3.5",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/debug/-/debug-4.3.5.tgz",
-      "integrity": "sha1-6DRE7Ouf7dSh2lbWca4kRqAabh4=",
+      "version": "4.4.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha1-Kz8q6i/+t3ZHdGAmc3fchxD6uoo=",
       "license": "MIT",
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -8848,23 +8697,26 @@
       }
     },
     "node_modules/require-in-the-middle/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
+      "version": "2.1.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI=",
       "license": "MIT"
     },
     "node_modules/resolve": {
-      "version": "1.22.8",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/resolve/-/resolve-1.22.8.tgz",
-      "integrity": "sha1-tsh6nyqgbfq1Lj1wrIzeMh+lpI0=",
+      "version": "1.22.10",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/resolve/-/resolve-1.22.10.tgz",
+      "integrity": "sha1-tmPoP/sJu/I4aURza6roAwKbizk=",
       "license": "MIT",
       "dependencies": {
-        "is-core-module": "^2.13.0",
+        "is-core-module": "^2.16.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
       "bin": {
         "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -8903,9 +8755,9 @@
       }
     },
     "node_modules/resolve.exports": {
-      "version": "2.0.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/resolve.exports/-/resolve.exports-2.0.2.tgz",
-      "integrity": "sha1-+Mk0uOahP1OeOLcJji42E08B6AA=",
+      "version": "2.0.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/resolve.exports/-/resolve.exports-2.0.3.tgz",
+      "integrity": "sha1-QZVebxtAE7dYb4c3SaY13qB+vj8=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8991,9 +8843,9 @@
       "license": "MIT"
     },
     "node_modules/rhea": {
-      "version": "3.0.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/rhea/-/rhea-3.0.2.tgz",
-      "integrity": "sha1-OILsRe12IJNsjIB4M9F9hKVySsc=",
+      "version": "3.0.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/rhea/-/rhea-3.0.3.tgz",
+      "integrity": "sha1-OP8US3+MqYKmdxiqH15nvZMHVnk=",
       "license": "Apache-2.0",
       "dependencies": {
         "debug": "^4.3.3"
@@ -9011,12 +8863,12 @@
       }
     },
     "node_modules/rhea-promise/node_modules/debug": {
-      "version": "4.3.5",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/debug/-/debug-4.3.5.tgz",
-      "integrity": "sha1-6DRE7Ouf7dSh2lbWca4kRqAabh4=",
+      "version": "4.4.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha1-Kz8q6i/+t3ZHdGAmc3fchxD6uoo=",
       "license": "MIT",
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -9028,18 +8880,18 @@
       }
     },
     "node_modules/rhea-promise/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
+      "version": "2.1.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI=",
       "license": "MIT"
     },
     "node_modules/rhea/node_modules/debug": {
-      "version": "4.3.5",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/debug/-/debug-4.3.5.tgz",
-      "integrity": "sha1-6DRE7Ouf7dSh2lbWca4kRqAabh4=",
+      "version": "4.4.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha1-Kz8q6i/+t3ZHdGAmc3fchxD6uoo=",
       "license": "MIT",
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -9051,24 +8903,51 @@
       }
     },
     "node_modules/rhea/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
+      "version": "2.1.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI=",
       "license": "MIT"
     },
     "node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha1-8aVAK6YiCtUswSgrrBrjqkn9Bho=",
+      "version": "2.4.5",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/rimraf/-/rimraf-2.4.5.tgz",
+      "integrity": "sha1-7nEM5dk6j9uFb7Xqj/Di11k0sto=",
       "license": "ISC",
+      "optional": true,
       "dependencies": {
-        "glob": "^7.1.3"
+        "glob": "^6.0.1"
       },
       "bin": {
         "rimraf": "bin.js"
+      }
+    },
+    "node_modules/rimraf/node_modules/glob": {
+      "version": "6.0.4",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/glob/-/glob-6.0.4.tgz",
+      "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "2 || 3",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/run-applescript": {
+      "version": "7.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/run-applescript/-/run-applescript-7.0.0.tgz",
+      "integrity": "sha1-5aVTwr/9Yg4WnSdsHNjxtkd4++s=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
-        "url": "https://github.com/sponsors/isaacs"
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/run-parallel": {
@@ -9122,9 +9001,9 @@
       "optional": true
     },
     "node_modules/safe-stable-stringify": {
-      "version": "2.4.3",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/safe-stable-stringify/-/safe-stable-stringify-2.4.3.tgz",
-      "integrity": "sha1-E4yEtvbts9tfjvPvcRW49VzL+IY=",
+      "version": "2.5.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha1-TKL444XygxxDKnGbEIo7969Cod0=",
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -9143,9 +9022,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/semver": {
-      "version": "7.6.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/semver/-/semver-7.6.2.tgz",
-      "integrity": "sha1-Hjs0dZ+Jbo8U1hNHMs55iusMbhM=",
+      "version": "7.7.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha1-q9UJjYKxjGyB9gdP8mR/0+ciDJ8=",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -9158,6 +9037,7 @@
       "version": "0.19.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/send/-/send-0.19.0.tgz",
       "integrity": "sha1-u8WjiMjqbASJZwSdvqwOSj8J1/g=",
+      "license": "MIT",
       "dependencies": {
         "debug": "2.6.9",
         "depd": "2.0.0",
@@ -9181,6 +9061,7 @@
       "version": "1.0.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -9188,12 +9069,13 @@
     "node_modules/send/node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI="
+      "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI=",
+      "license": "MIT"
     },
     "node_modules/sequelize": {
-      "version": "6.37.3",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/sequelize/-/sequelize-6.37.3.tgz",
-      "integrity": "sha1-7WISAppSxZoYY40qcD2oS8L4ExE=",
+      "version": "6.37.5",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/sequelize/-/sequelize-6.37.5.tgz",
+      "integrity": "sha1-JxGrl9Dg/knGUjaJRqcxLrDxHNc=",
       "funding": [
         {
           "type": "opencollective",
@@ -9273,12 +9155,12 @@
       }
     },
     "node_modules/sequelize/node_modules/debug": {
-      "version": "4.3.5",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/debug/-/debug-4.3.5.tgz",
-      "integrity": "sha1-6DRE7Ouf7dSh2lbWca4kRqAabh4=",
+      "version": "4.4.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha1-Kz8q6i/+t3ZHdGAmc3fchxD6uoo=",
       "license": "MIT",
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -9290,9 +9172,9 @@
       }
     },
     "node_modules/sequelize/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
+      "version": "2.1.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI=",
       "license": "MIT"
     },
     "node_modules/sequelize/node_modules/uuid": {
@@ -9308,6 +9190,7 @@
       "version": "1.16.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/serve-static/-/serve-static-1.16.2.tgz",
       "integrity": "sha1-tqU0PaR/a90mc4SL9FdUlB6AMpY=",
+      "license": "MIT",
       "dependencies": {
         "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
@@ -9316,23 +9199,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/set-function-length": {
-      "version": "1.2.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/set-function-length/-/set-function-length-1.2.2.tgz",
-      "integrity": "sha1-qscjFBmOrtl1z3eyw7a4gGleVEk=",
-      "license": "MIT",
-      "dependencies": {
-        "define-data-property": "^1.1.4",
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2",
-        "get-intrinsic": "^1.2.4",
-        "gopd": "^1.0.1",
-        "has-property-descriptors": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/setprototypeof": {
@@ -9369,15 +9235,69 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/side-channel": {
-      "version": "1.0.6",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/side-channel/-/side-channel-1.0.6.tgz",
-      "integrity": "sha1-q9Jft80kuvRUZkBrEJa3gxySFfI=",
+      "version": "1.1.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha1-w/z/nE2pMnhIczNeyXZfqU/2a8k=",
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
         "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.4",
-        "object-inspect": "^1.13.1"
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha1-EMtZhCYxFdO3oOM2WR4pCoMK+K0=",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha1-1rtrN5Asb+9RdOX1M/q0xzKib0I=",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha1-Ed2hnVNo5Azp7CvcH7DsvAeQ7Oo=",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -9480,19 +9400,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/slice-ansi/node_modules/is-fullwidth-code-point": {
-      "version": "4.0.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz",
-      "integrity": "sha1-+uMWfHKedGP4RhzlErCApJJoqog=",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/source-map": {
@@ -9628,18 +9535,50 @@
       }
     },
     "node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha1-JpxxF9J7Ba0uU2gwqOyJXvnG0BA=",
+      "version": "7.2.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha1-tbuOIWXOJ11NQ0dt0nAK2Qkdttw=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width/node_modules/ansi-regex": {
+      "version": "6.1.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ansi-regex/-/ansi-regex-6.1.0.tgz",
+      "integrity": "sha1-lexAnGlhnWyxuLNPFLZg7yjr1lQ=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/string-width/node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha1-1bZWjKaJ2FYTcLBwdoXSJDT6/0U=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/strip-ansi": {
@@ -9687,9 +9626,15 @@
       }
     },
     "node_modules/strnum": {
-      "version": "1.0.5",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/strnum/-/strnum-1.0.5.tgz",
-      "integrity": "sha1-XE6Cn+Fa1P8NIMPbWsl7c8mwcts=",
+      "version": "1.1.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/strnum/-/strnum-1.1.1.tgz",
+      "integrity": "sha1-azEpNAVFlN1hG9GNm8zlBTp8qu4=",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
       "license": "MIT"
     },
     "node_modules/superagent": {
@@ -9715,13 +9660,13 @@
       }
     },
     "node_modules/superagent/node_modules/debug": {
-      "version": "4.3.5",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/debug/-/debug-4.3.5.tgz",
-      "integrity": "sha1-6DRE7Ouf7dSh2lbWca4kRqAabh4=",
+      "version": "4.4.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha1-Kz8q6i/+t3ZHdGAmc3fchxD6uoo=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -9746,9 +9691,9 @@
       }
     },
     "node_modules/superagent/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
+      "version": "2.1.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI=",
       "dev": true,
       "license": "MIT"
     },
@@ -9791,11 +9736,12 @@
       }
     },
     "node_modules/tedious": {
-      "version": "18.2.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/tedious/-/tedious-18.2.1.tgz",
-      "integrity": "sha1-s4IYi6e1yAo7Empch26C9P9efwk=",
+      "version": "18.6.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/tedious/-/tedious-18.6.1.tgz",
+      "integrity": "sha1-HEo/BsiRvmegMhF+LiUZMobURJY=",
       "license": "MIT",
       "dependencies": {
+        "@azure/core-auth": "^1.7.2",
         "@azure/identity": "^4.2.1",
         "@azure/keyvault-keys": "^4.4.0",
         "@js-joda/core": "^5.6.1",
@@ -9856,16 +9802,6 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
-    "node_modules/to-fast-properties": {
-      "version": "2.0.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -9914,9 +9850,9 @@
       }
     },
     "node_modules/ts-api-utils": {
-      "version": "2.0.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ts-api-utils/-/ts-api-utils-2.0.0.tgz",
-      "integrity": "sha1-udfV9+yfc29NDwl1i4YHl5BEqQA=",
+      "version": "2.0.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ts-api-utils/-/ts-api-utils-2.0.1.tgz",
+      "integrity": "sha1-ZgcpOFtiW5OaqlgFT0XAWPM/EM0=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9927,9 +9863,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha1-BDj4EK16ntzeeiQcPYDbaTyMv+A=",
+      "version": "2.8.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha1-YS7+TtI11Wfoq6Xypfq3AoCt6D8=",
       "license": "0BSD"
     },
     "node_modules/type-check": {
@@ -9955,9 +9891,10 @@
       }
     },
     "node_modules/type-fest": {
-      "version": "0.20.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/type-fest/-/type-fest-0.20.2.tgz",
-      "integrity": "sha1-G/IH9LKPkVg2ZstfvTJ4hzAc1fQ=",
+      "version": "0.21.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha1-0mCiSwGYQ24TP6JqUkptZfo7Ljc=",
+      "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=10"
@@ -9980,9 +9917,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.7.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/typescript/-/typescript-5.7.2.tgz",
-      "integrity": "sha1-MWnPjEyKgozeU7qeyz0rHV3We+Y=",
+      "version": "5.7.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/typescript/-/typescript-5.7.3.tgz",
+      "integrity": "sha1-kZtEp9u4WDqbhW0WK+JKVL+ABz4=",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
@@ -10002,9 +9939,9 @@
       "license": "MIT"
     },
     "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha1-vNU5iT0AtW6WT9JlekhmsiGmVhc=",
+      "version": "6.20.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/undici-types/-/undici-types-6.20.0.tgz",
+      "integrity": "sha1-gXG/IsH1iNFVTVW/IEvGJK84hDM=",
       "license": "MIT"
     },
     "node_modules/unpipe": {
@@ -10017,9 +9954,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.0.16",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/update-browserslist-db/-/update-browserslist-db-1.0.16.tgz",
-      "integrity": "sha1-9tSJ7ZD7LwfWd4TrP1PXiR9zY1Y=",
+      "version": "1.1.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/update-browserslist-db/-/update-browserslist-db-1.1.2.tgz",
+      "integrity": "sha1-l+nJarCue8rAjprlFR0m5rxrVYA=",
       "dev": true,
       "funding": [
         {
@@ -10037,8 +9974,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "escalade": "^3.1.2",
-        "picocolors": "^1.0.1"
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
       },
       "bin": {
         "update-browserslist-db": "cli.js"
@@ -10162,35 +10099,35 @@
       }
     },
     "node_modules/winston": {
-      "version": "3.15.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/winston/-/winston-3.15.0.tgz",
-      "integrity": "sha1-Tfe3C+CRvBo4pPRblp+nlYm3P/U=",
+      "version": "3.17.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/winston/-/winston-3.17.0.tgz",
+      "integrity": "sha1-dLhmXOm06nsp0JIs/M+FKgihFCM=",
       "license": "MIT",
       "dependencies": {
         "@colors/colors": "^1.6.0",
         "@dabh/diagnostics": "^2.0.2",
         "async": "^3.2.3",
         "is-stream": "^2.0.0",
-        "logform": "^2.6.0",
+        "logform": "^2.7.0",
         "one-time": "^1.0.0",
         "readable-stream": "^3.4.0",
         "safe-stable-stringify": "^2.3.1",
         "stack-trace": "0.0.x",
         "triple-beam": "^1.3.0",
-        "winston-transport": "^4.7.0"
+        "winston-transport": "^4.9.0"
       },
       "engines": {
         "node": ">= 12.0.0"
       }
     },
     "node_modules/winston-transport": {
-      "version": "4.7.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/winston-transport/-/winston-transport-4.7.0.tgz",
-      "integrity": "sha1-4wLmiJ5sy384O5Jt9pNqW3gb0fA=",
+      "version": "4.9.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/winston-transport/-/winston-transport-4.9.0.tgz",
+      "integrity": "sha1-O7o0XeECl2VOpvM1GUJFYAA7O/k=",
       "license": "MIT",
       "dependencies": {
-        "logform": "^2.3.2",
-        "readable-stream": "^3.6.0",
+        "logform": "^2.7.0",
+        "readable-stream": "^3.6.2",
         "triple-beam": "^1.3.0"
       },
       "engines": {
@@ -10244,21 +10181,63 @@
       }
     },
     "node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha1-Z+FFz/UQpqaYS98RUpEdadLrnkM=",
+      "version": "9.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/wrap-ansi/-/wrap-ansi-9.0.0.tgz",
+      "integrity": "sha1-Gj3Itw2F7rg5jd+x5KAs0Ybliz4=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-regex": {
+      "version": "6.1.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ansi-regex/-/ansi-regex-6.1.0.tgz",
+      "integrity": "sha1-lexAnGlhnWyxuLNPFLZg7yjr1lQ=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ansi-styles/-/ansi-styles-6.2.1.tgz",
+      "integrity": "sha1-DmIyDPmcIa//OzASGSVGqsv7BcU=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha1-1bZWjKaJ2FYTcLBwdoXSJDT6/0U=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/wrappy": {
@@ -10315,9 +10294,9 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.6.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/yaml/-/yaml-2.6.1.tgz",
-      "integrity": "sha1-QvKxuokgPzdGCVctU0n7hoZQB3M=",
+      "version": "2.7.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/yaml/-/yaml-2.7.0.tgz",
+      "integrity": "sha1-rvm7YXpkyTepp0iAN4atjT/+Hpg=",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -10354,6 +10333,38 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/yargs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc=",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yargs/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha1-JpxxF9J7Ba0uU2gwqOyJXvnG0BA=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -2,9 +2,6 @@
   "name": "login.dfe.public-api",
   "version": "8.0.0",
   "description": "",
-  "engines": {
-    "node": "18.x.x"
-  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/DFE-Digital/login.dfe.node-boilerplate.git"
@@ -31,30 +28,30 @@
     "clearMocks": true
   },
   "dependencies": {
-    "agentkeepalive": "^4.5.0",
+    "agentkeepalive": "^4.6.0",
     "applicationinsights": "^2.9.1",
-    "body-parser": "^1.18.3",
+    "body-parser": "^1.20.3",
     "email-validator": "^2.0.4",
-    "express": "^4.16.3",
-    "express-validator": "^7.0.1",
+    "express": "^4.21.2",
+    "express-validator": "^7.2.1",
     "helmet": "^7.1.0",
     "jsonwebtoken": "^9.0.2",
-    "lodash": "^4.17.15",
+    "lodash": "^4.17.21",
     "login.dfe.api.auth": "github:DFE-Digital/login.dfe.api.auth#v2.3.3",
     "login.dfe.async-retry": "github:DFE-Digital/login.dfe.async-retry#v2.0.3",
-    "login.dfe.audit.transporter": "^4.0.1",
+    "login.dfe.audit.transporter": "^4.0.2",
     "login.dfe.audit.winston-sequelize-transport": "github:DFE-Digital/login.dfe.audit.winston-sequelize-transport#v3.2.4",
     "login.dfe.dao": "^5.0.3",
-    "login.dfe.express-error-handling": "github:DFE-Digital/login.dfe.express-error-handling#v3.0.1",
+    "login.dfe.express-error-handling": "github:DFE-Digital/login.dfe.express-error-handling#v3.0.2",
     "login.dfe.healthcheck": "github:DFE-Digital/login.dfe.healthcheck#v3.0.2",
     "login.dfe.jobs-client": "github:DFE-Digital/login.dfe.jobs-client#v6.1.0",
     "login.dfe.jwt-strategies": "github:DFE-Digital/login.dfe.jwt-strategies#v4.1.1",
-    "login.dfe.sanitization": "github:DFE-Digital/login.dfe.sanitization#v3.0.1",
+    "login.dfe.sanitization": "^3.0.4",
     "login.dfe.winston-appinsights": "github:DFE-Digital/login.dfe.winston-appinsights#v5.0.3",
     "niceware": "^4.0.0",
-    "uuid": "^9.0.1",
+    "uuid": "^10.0.0",
     "valid-url": "^1.0.9",
-    "winston": "^3.11.0"
+    "winston": "^3.15.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.17.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "login.dfe.api.auth": "github:DFE-Digital/login.dfe.api.auth#v2.3.3",
     "login.dfe.async-retry": "github:DFE-Digital/login.dfe.async-retry#v2.0.3",
     "login.dfe.audit.transporter": "^4.0.2",
-    "login.dfe.audit.winston-sequelize-transport": "github:DFE-Digital/login.dfe.audit.winston-sequelize-transport#v3.2.4",
     "login.dfe.dao": "^5.0.3",
     "login.dfe.express-error-handling": "github:DFE-Digital/login.dfe.express-error-handling#v3.0.2",
     "login.dfe.healthcheck": "github:DFE-Digital/login.dfe.healthcheck#v3.0.2",


### PR DESCRIPTION
### Summary
Jira ticket: https://dfe-secureaccess.atlassian.net/browse/DSI-7552

### Changes

- Update pipeline related files for Node 22, specifically 22.11.0
- Updated to use the latest DfE components
- Updated some of the 3rd party packages where deemed safe
- Removed unused `login.dfe.audit.winston-sequelize-transport` package.
